### PR TITLE
Add Lwt_cstruct.complete convenience function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+1.2.1 (unreleased)
+* Add 'Lwt_cstruct.complete' convenience function
+
 1.2.0 (2014-06-06):
 
 Add a `sexp` optional decorator to `cenum` to output the values as s-expressions.

--- a/lwt/lwt_cstruct.ml
+++ b/lwt/lwt_cstruct.ml
@@ -20,6 +20,18 @@ let read fd t =
 let write fd t =
   Lwt_bytes.write fd t.Cstruct.buffer t.Cstruct.off t.Cstruct.len
 
+let complete op t =
+  let open Lwt in
+  let rec loop t =
+    op t >>= fun n ->
+    let t = Cstruct.shift t n in
+    if Cstruct.len t = 0
+    then return ()
+    else if n = 0
+    then fail End_of_file
+    else loop t in
+  loop t
+
 let sendto fd t flags dst =
   Lwt_bytes.sendto fd t.Cstruct.buffer t.Cstruct.off t.Cstruct.len flags dst
 

--- a/lwt/lwt_cstruct.mli
+++ b/lwt/lwt_cstruct.mli
@@ -19,6 +19,11 @@ val read: Lwt_unix.file_descr -> Cstruct.t -> int Lwt.t
 
 val write: Lwt_unix.file_descr -> Cstruct.t -> int Lwt.t
 
+val complete: (Cstruct.t -> int Lwt.t) -> Cstruct.t -> unit Lwt.t
+(** [complete (read fd) t] fills [t] with data from [fd] or fails with End_of_file
+    [complete (write fd) t] fully-writes [t] to [fd] or fails with End_of_file
+  *)
+
 val sendto: Lwt_unix.file_descr -> Cstruct.t -> Unix.msg_flag list -> Unix.sockaddr -> int Lwt.t
 
 val recvfrom: Lwt_unix.file_descr -> Cstruct.t -> Unix.msg_flag list -> (int * Unix.sockaddr) Lwt.t


### PR DESCRIPTION
When dealing with functions like 'read' and 'write' which return
an integer which means:
  0: End_of_file
  n: n bytes written
we can now write 'complete read' which will keep executing 'read'
until the whole buffer has been processed, returning () or
failing with End_of_file.

Signed-off-by: David Scott dave.scott@citrix.com

This is a common pattern which I've ended up reimplementing all over the place.
