### PR TITLE
Add buffer function

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+* Added `buffer` function.
+
 1.5.0 (2014-11-24):
 * Make `camlp4` an optional build-time dependency (#35).
 * Remove `ounit` as a dependency in the `opam` file.

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -231,6 +231,22 @@ let copyv ts =
     ) 0 ts in
   dst
 
+let buffer src dst =
+  let rec aux dst n = function
+    | [] -> n, []   (* src exhausted *)
+    | hd::tl ->
+        let avail = len dst in
+        let first = len hd in
+        if first <= avail then (
+          blit hd 0 dst 0 first;
+          aux (shift dst first) (n + first) tl
+        ) else (
+          blit hd 0 dst 0 avail;
+          let rest_hd = shift hd first in
+          (n + avail, rest_hd :: tl)    (* dst full *)
+        ) in
+  aux dst 0 src
+
 let to_string t =
   let sz = len t in
   let s = String.create sz in

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -378,6 +378,11 @@ val copyv: t list -> string
 (** [copyv cstrs] is the string representation of the concatenation of
     all cstructs in [cstrs]. *)
 
+val buffer: t list -> t -> int * t list
+(** [buffer src dst] copies from [src] to [dst] until [src] is exhausted or [dst] is full.
+ * Returns the number of bytes copied and the remaining data from [src], if any.
+ * This is useful if you want buffer data into fixed-sized chunks. *)
+
 (** {2 Iterations} *)
 
 type 'a iter = unit -> 'a option


### PR DESCRIPTION
This is useful if you want to buffer data into fixed-sized chunks.
It was originally in mirage-net-xen. @samoht suggested moving it here (https://github.com/mirage/mirage-net-xen/pull/17/files#r22857225).