### PR TITLE
Sexp conversions: ignore extra bytes

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -19,14 +19,11 @@ open Sexplib.Std
 
 type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
-let buffer_of_sexp b = Sexplib.Conv.bigstring_of_sexp b
-let sexp_of_buffer b = Sexplib.Conv.sexp_of_bigstring b
-
 type t = {
   buffer: buffer;
   off   : int;
   len   : int;
-} with sexp
+}
 
 let of_bigarray ?(off=0) ?len buffer =
   let dim = Bigarray.Array1.dim buffer in
@@ -312,3 +309,9 @@ let iter lenfn pfn buf =
 let rec fold f next acc = match next () with
   | None -> acc
   | Some v -> fold f next (f acc v)
+
+let buffer_of_sexp b = Sexplib.Conv.bigstring_of_sexp b
+let sexp_of_buffer b = Sexplib.Conv.sexp_of_bigstring b
+
+let t_of_sexp s = of_bigarray (buffer_of_sexp s)
+let sexp_of_t t = sexp_of_buffer (to_bigarray t)

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -310,8 +310,22 @@ let rec fold f next acc = match next () with
   | None -> acc
   | Some v -> fold f next (f acc v)
 
-let buffer_of_sexp b = Sexplib.Conv.bigstring_of_sexp b
-let sexp_of_buffer b = Sexplib.Conv.sexp_of_bigstring b
 
-let t_of_sexp s = of_bigarray (buffer_of_sexp s)
-let sexp_of_t t = sexp_of_buffer (to_bigarray t)
+open Sexplib
+
+let buffer_of_sexp b = Conv.bigstring_of_sexp b
+let sexp_of_buffer b = Conv.sexp_of_bigstring b
+
+let t_of_sexp = function
+  | Sexp.Atom str ->
+      let n = String.length str in
+      let t = create n in
+      blit_from_string str 0 t 0 n ;
+      t
+  | sexp -> Conv.of_sexp_error "Cstruct.t_of_sexp: atom needed" sexp
+
+let sexp_of_t t =
+  let n   = len t in
+  let str = String.create n in
+  blit_to_string t 0 str 0 n ;
+  Sexp.Atom str


### PR DESCRIPTION
The current sexp conversions marshal the entire structure, including the full underlying buffer.

This is desirable if `Cstruct.t` is understood as a `char bigarray` with a handy offset and a limit. If it's understood as a *view* into the underlying array, then its meaning are exactly the bytes in the array between `offset` and `offset + length`. Marshaling the entire array then leaks the details on how the view was originally obtained.

I would argue that since it's impossible to expand a cstruct, the latter is a better description of what cstructs are. Bytes beyond the stored range are not accessible through the functions in `Cstruct`, and should not be serialized either. If this is desired, one can easily store the buffer directly, as the type is not opaque.

This bit me when I tried to remove the custom `from`/`to_sexp` routines from tls and use the ones here; we end up storing large amounts of data, as various bits of internal state are cut-up slices of larger buffers.