### PR TITLE
Cstruct comparison

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -149,7 +149,8 @@ let compare t1 t2 =
   | 0 -> compare l1 l2
   | r -> if r < 0 then -1 else 1
 
-let equal t1 t2 = compare t1 t2 = 0
+let equal t1 t2 =
+  t1.len = t2.len && compare t1 t2 = 0
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then raise (Invalid_argument (invalid_bounds i 1)) ;

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -145,12 +145,14 @@ let blit_to_string src srcoff dst dstoff len =
 let compare t1 t2 =
   let l1 = t1.len
   and l2 = t2.len in
-  match unsafe_compare_bigstring t1.buffer t1.off t2.buffer t2.off (min l1 l2) with
-  | 0 -> compare l1 l2
-  | r -> if r < 0 then -1 else 1
+  match compare l1 l2 with
+  | 0 ->
+    ( match unsafe_compare_bigstring t1.buffer t1.off t2.buffer t2.off l1 with
+      | 0 -> 0
+      | r -> if r < 0 then -1 else 1 )
+  | r -> r
 
-let equal t1 t2 =
-  t1.len = t2.len && compare t1 t2 = 0
+let equal t1 t2 = compare t1 t2 = 0
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then raise (Invalid_argument (invalid_bounds i 1)) ;

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -119,6 +119,8 @@ external unsafe_blit_string_to_bigstring : string -> int -> buffer -> int -> int
 
 external unsafe_blit_bigstring_to_string : buffer -> int -> string -> int -> int -> unit = "caml_blit_bigstring_to_string" "noalloc"
 
+external unsafe_compare_bigstring : buffer -> int -> buffer -> int -> int -> int = "caml_compare_bigstring" "noalloc"
+
 let copy src srcoff len =
   if len < 0 || srcoff < 0 || src.len - srcoff < len then raise (Invalid_argument (invalid_bounds srcoff len));
   let s = String.create len in
@@ -139,6 +141,15 @@ let blit_to_string src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || dstoff < 0 || src.len - srcoff < len then raise (Invalid_argument (invalid_bounds srcoff len));
   if String.length dst - dstoff < len then raise (Invalid_argument (invalid_bounds dstoff len));
   unsafe_blit_bigstring_to_string src.buffer (src.off+srcoff) dst dstoff len
+
+let compare t1 t2 =
+  let l1 = t1.len
+  and l2 = t2.len in
+  match unsafe_compare_bigstring t1.buffer t1.off t2.buffer t2.off (min l1 l2) with
+  | 0 -> compare l1 l2
+  | r -> if r < 0 then -1 else 1
+
+let equal t1 t2 = compare t1 t2 = 0
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then raise (Invalid_argument (invalid_bounds i 1)) ;

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -181,6 +181,16 @@ val of_string: ?allocator:(int -> t) -> string -> t
     with the underlying buffer allocated by [alloc]. If [allocator] is not
     provided, [create] is used. *)
 
+(** {2 Comparison } *)
+
+val equal : t -> t -> bool
+(** [equal t1 t2] is [true] iff [t1] and [t2] correspond to the same sequence of
+    bytes. *)
+
+val compare : t -> t -> int
+(** [compare t1 t2] is [-1] if [t1] precedes [t2] by lexicographical order, [1]
+    if [t2] precedes [t1], and [0] otherwise. *)
+
 (** {2 Getters and Setters } *)
 
 val byte_to_int : byte -> int

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -188,8 +188,7 @@ val equal : t -> t -> bool
     bytes. *)
 
 val compare : t -> t -> int
-(** [compare t1 t2] is [-1] if [t1] precedes [t2] by lexicographical order, [1]
-    if [t2] precedes [t1], and [0] otherwise. *)
+(** [compare t1 t2] gives an unspecified total ordering over {!t}. *)
 
 (** {2 Getters and Setters } *)
 

--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -51,3 +51,12 @@ caml_blit_bigstring_to_bigstring(value val_buf1, value val_ofs1, value val_buf2,
          Long_val(val_len));
   return Val_unit;
 }
+
+CAMLprim value
+caml_compare_bigstring(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
+{
+  int res = memcmp((char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
+                   (char*)Caml_ba_data_val(val_buf2) + Long_val(val_ofs2),
+                   Long_val(val_len));
+  return Val_int(res);
+}


### PR DESCRIPTION
Adds `compare` and `equal` based on `memcmp`.

Fixes #23 and #24.