### PR TITLE
Expose memset

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -118,6 +118,8 @@ external unsafe_blit_bigstring_to_string : buffer -> int -> string -> int -> int
 
 external unsafe_compare_bigstring : buffer -> int -> buffer -> int -> int -> int = "caml_compare_bigstring" "noalloc"
 
+external unsafe_fill_bigstring : buffer -> int -> int -> int -> unit = "caml_fill_bigstring" "noalloc"
+
 let copy src srcoff len =
   if len < 0 || srcoff < 0 || src.len - srcoff < len then raise (Invalid_argument (invalid_bounds srcoff len));
   let s = String.create len in
@@ -150,6 +152,8 @@ let compare t1 t2 =
   | r -> r
 
 let equal t1 t2 = compare t1 t2 = 0
+
+let set t x = unsafe_fill_bigstring t.buffer t.off t.len x
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then raise (Invalid_argument (invalid_bounds i 1)) ;

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -153,7 +153,7 @@ let compare t1 t2 =
 
 let equal t1 t2 = compare t1 t2 = 0
 
-let set t x = unsafe_fill_bigstring t.buffer t.off t.len x
+let memset t x = unsafe_fill_bigstring t.buffer t.off t.len x
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then raise (Invalid_argument (invalid_bounds i 1)) ;

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -19,6 +19,17 @@ open Sexplib.Std
 
 type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
+(* Note:
+ *
+ * We try to maintain the property that no constructed [t] can ever point out of
+ * its underlying buffer. This property is guarded by all of the constructing
+ * functions and the fact that the type is private, and used by various
+ * functions that would otherwise be completely unsafe.
+ *
+ * All well-intended souls are kindly invited to cross-check that the code
+ * indeed maintains this invariant.
+ *)
+
 type t = {
   buffer: buffer;
   off   : int;
@@ -153,6 +164,7 @@ let compare t1 t2 =
 
 let equal t1 t2 = compare t1 t2 = 0
 
+(* Note that this is only safe as long as all [t]s are coherent. *)
 let memset t x = unsafe_fill_bigstring t.buffer t.off t.len x
 
 let set_uint8 t i c =

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -262,6 +262,9 @@ val blit_to_string: t -> int -> string -> int -> int -> unit
     valid segment of [src], or if [dstoff] and [len] do not designate
     a valid substring of [dst]. *)
 
+val set: t -> int -> unit
+(** [set t x] sets all the bytes of [t] to [x land 0xff]. *)
+
 val len: t -> int
 (** Returns the length of the current cstruct view.  Note that this
     length is potentially smaller than the actual size of the underlying

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -262,8 +262,8 @@ val blit_to_string: t -> int -> string -> int -> int -> unit
     valid segment of [src], or if [dstoff] and [len] do not designate
     a valid substring of [dst]. *)
 
-val set: t -> int -> unit
-(** [set t x] sets all the bytes of [t] to [x land 0xff]. *)
+val memset: t -> int -> unit
+(** [memset t x] sets all the bytes of [t] to [x land 0xff]. *)
 
 val len: t -> int
 (** Returns the length of the current cstruct view.  Note that this

--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -60,3 +60,12 @@ caml_compare_bigstring(value val_buf1, value val_ofs1, value val_buf2, value val
                    Long_val(val_len));
   return Val_int(res);
 }
+
+CAMLprim value
+caml_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
+{
+  memset((char*)Caml_ba_data_val(val_buf) + Long_val(val_ofs),
+         Int_val(val_byte),
+         Long_val(val_len));
+  return Val_unit;
+}


### PR DESCRIPTION
This adds `memset`.

I realize adding more C to `cstruct` is not to be taken lightly, but a fast way to set all the bytes in a buffer is often desirable. `nocrypto` already uses memset on cstructs ([here](https://github.com/mirleft/ocaml-nocrypto/blob/master/src/uncommon.ml#L126) through [this](https://github.com/mirleft/ocaml-nocrypto/blob/master/src_gen/bindings.ml#L13)), at some point there was talk about initializing all constructed cstructs to `0x00`, and I imagine there might be other uses of this.

The operation is named `set` because `fill` is confusingly similar to `fillv`.