### PR TITLE
Concatenators

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -380,6 +380,24 @@ let rec fold f next acc = match next () with
   | None -> acc
   | Some v -> fold f next (f acc v)
 
+let append cs1 cs2 =
+  let l1 = len cs1 and l2 = len cs2 in
+  let cs = create (l1 + l2) in
+  blit cs1 0 cs 0  l1 ;
+  blit cs2 0 cs l1 l2 ;
+  cs
+
+let concat = function
+  | []   -> create 0
+  | [cs] -> cs
+  | css  ->
+      let result = create (lenv css) in
+      let aux off cs =
+        let n = len cs in
+        blit cs 0 result off n ;
+        off + n in
+      ignore @@ List.fold_left aux 0 css ;
+      result
 
 open Sexplib
 

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -406,3 +406,10 @@ val iter: (t -> int option) -> (t -> 'a) -> t -> 'a iter
 
 val fold: ('b -> 'a -> 'b) -> 'a iter -> 'b -> 'b
 (** [fold f iter acc] is [(f iterN accN ... (f iter acc)...)]. *)
+
+val append: t -> t -> t
+(** [append t1 t2] is the concatenation [t1 || t2]. *)
+
+val concat: t list -> t
+(** [concat ts] is the concatenation of all the [ts]. It is not guaranteed that
+ * the result is a newly created [t] in the zero- and one-element cases. *)

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -2,6 +2,11 @@ open OUnit
 
 let _ = Random.self_init ()
 
+let random_cs ?(len = Random.int 128) () =
+  let cs = Cstruct.create len in
+  for i = 0 to len - 1 do Cstruct.set_uint8 cs i (Random.int 256) done;
+  cs
+
 let to_string_as_sexp cs =
   Sexplib.Sexp.to_string_mach (Cstruct.sexp_of_t cs)
 
@@ -37,19 +42,46 @@ let sexp_reader () =
     assert_cs_equal cs (of_string_as_sexp str)
 
 let sexp_invertibility ~n () =
-  let create_random () =
-    let n  = Random.int 128 in
-    let cs = Cstruct.create n in
-    for i = 0 to n - 1 do Cstruct.set_uint8 cs i (Random.int 256) done;
-    cs
-  in
   for i = 1 to n do
-    let cs1 = create_random () in
+    let cs1 = random_cs () in
     let s1  = to_string_as_sexp cs1 in
     let cs2 = of_string_as_sexp s1  in
     let s2  = to_string_as_sexp cs2 in
     assert_cs_equal     ~msg:"recovered cstruct" cs1 cs2 ;
     assert_string_equal ~msg:"recovered string"  s1  s2
+  done
+
+let concat_ex =
+  let open Cstruct in
+  List.map (fun (ss, s) -> (List.map of_string ss, of_string s))
+  [ ([], "")
+  ; (["abcd"], "abcd")
+  ; ([""], "")
+  ; ([""; ""], "")
+  ; ([""; "ab"; ""; "cd"], "abcd")
+  ; (["ab"; "cd"; "ef"], "abcdef")
+  ]
+
+let concat_samples () =
+  concat_ex |> List.iter @@ fun (css, cs) ->
+    assert_cs_equal cs (Cstruct.concat css)
+
+let concat_random ~n () =
+  let rec explode cs =
+    let n = Cstruct.len cs in
+    if n = 0 then [] else
+      let k = Random.int (n + 1) in
+      Cstruct.sub cs 0 k :: explode (Cstruct.shift cs k) in
+  for i = 1 to n do
+    let cs  = random_cs () in
+    let css = explode cs in
+    assert_cs_equal cs (Cstruct.concat css)
+  done
+
+let append_is_concat ~n () =
+  for i = 1 to n do
+    let (cs1, cs2) = (random_cs (), random_cs ()) in
+    assert_cs_equal (Cstruct.concat [cs1; cs2]) (Cstruct.append cs1 cs2)
   done
 
 let _ =
@@ -59,6 +91,13 @@ let _ =
         "sexp_of_t" >:: sexp_writer
       ; "t_of_sexp" >:: sexp_reader
       ; "sexp invertibility" >:: sexp_invertibility ~n:5000
+      ] ;
+      "concat" >::: [
+        "concat samples" >:: concat_samples
+      ; "concat random"  >:: concat_random ~n:5000
+      ] ;
+      "append" >::: [
+        "append is concat" >:: append_is_concat ~n:5000
       ]
     ]
   in


### PR DESCRIPTION
`concat` and  `append` from `nocrypto`, as [discussed](https://github.com/mirleft/ocaml-nocrypto/issues/50#issuecomment-89523111).

`concat` has a very value-like semantics in that it maps `[x]` to `x` itself without making a copy. This is beneficial in `nocrypto` as single-buffer situations can be treated as special cases of multi-buffer ones without that little bit of overhead. It's also documented, but maybe bears pointing out explicitly.

I personally like the operator form of `append`, `<+>`, but didn't include it not to extend the API too much. If others think they too prefer `foo <+> bar` to `append foo bar`, I can either add an alias or completely rename it.