### PR TITLE
Add javascript stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ configure:
 
 # OASIS_STOP
 
+JS_DIR ?= $(shell ocamlfind query cstruct)
+
 .PHONY: js-install js-uninstall
 js-install:
-	install -m 0644 js/cstruct.js $(shell ocamlfind query cstruct)
+	install -m 0644 js/cstruct.js $(JS_DIR)
 
 js-uninstall:
-	rm $(shell ocamlfind query cstruct)/cstruct.js
+	rm $(JS_DIR)/cstruct.js

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,10 @@ configure:
 .PHONY: build doc test all install uninstall reinstall clean distclean configure
 
 # OASIS_STOP
+
+.PHONY: js-install js-uninstall
+js-install:
+	install -m 0644 js/cstruct.js $(shell ocamlfind query cstruct)
+
+js-uninstall:
+	rm $(shell ocamlfind query cstruct)/cstruct.js

--- a/js/cstruct.js
+++ b/js/cstruct.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 Citrix Inc
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+//Provides: caml_blit_string_to_bigstring
+//Requires: caml_ba_set_1, caml_string_unsafe_get
+function caml_blit_string_to_bigstring(str, str_off, buf, buf_off, len) {
+  var i;
+  for (i = 0; i < len; i++) {
+    caml_ba_set_1(buf, buf_off + i, caml_string_unsafe_get(str, str_off + i));
+  }
+  return 0;
+}
+
+//Provides: caml_blit_bigstring_to_string
+//Requires: caml_ba_get_1, caml_string_unsafe_set
+function caml_blit_bigstring_to_string(buf, buf_off, str, str_off, len) {
+  var i;
+  for (i = 0; i < len; i++) {
+    caml_string_unsafe_set(str, str_off + i, caml_ba_get_1(buf, buf_off + i));
+  }
+  return 0;
+}
+
+//Provides: caml_blit_bigstring_to_bigstring
+//Requires: caml_ba_get_1, caml_ba_set_1
+function caml_blit_bigstring_to_bigstring(src, src_off, dst, dst_off, len) {
+  var i;
+  for (i = 0; i < len; i++) {
+    caml_ba_set_1(dst, dst_off + i, caml_ba_get_1(src, src_off + i));
+  }
+  return 0;
+}
+
+//Provides: caml_compare_bigstring
+//Requires: caml_int_compare, caml_ba_get_1
+function caml_compare_bigstring(buf1, buf1_off, buf2, buf2_off, len) {
+  var i, r;
+  for (i = 0; i < len; i++) {
+    r = caml_int_compare(caml_ba_get_1(buf1, buf1_off + i), caml_ba_get_1(buf2, buf2_off + i));
+    if (r != 0) return r;
+  }
+  return 0;
+}
+
+//Provides: caml_fill_bigstring
+//Requires: caml_ba_set_1
+function caml_fill_bigstring(buf, buf_off, buf_len, v) {
+  var i;
+  for (i = 0; i < buf_len; i++) {
+    caml_ba_set_1(buf, buf_off + i, v);
+  }
+  return 0;
+}

--- a/opam
+++ b/opam
@@ -32,8 +32,14 @@ build-test: [
   [make]
   ["./test.sh"]
 ]
-install: [make "install"]
-remove:  ["ocamlfind" "remove" "cstruct"]
+install: [
+  [make "install"]
+  [make "js-install"]
+]
+remove:  [
+  [make "js-uninstall"]
+  ["ocamlfind" "remove" "cstruct"]
+]
 depends: [
   "ocamlfind" {build}
   "ounit" {test}


### PR DESCRIPTION
This allows javascript programs to use the full cstruct library.

Note: to link the stubs you must add the argument
  `+cstruct/cstruct.js`
to the js_of_ocaml command-line.

Fixes #63

Signed-off-by: David Scott <dave.scott@citrix.com>