### PR TITLE
Remove name/version in opam file

### DIFF
--- a/opam
+++ b/opam
@@ -1,6 +1,4 @@
 opam-version: "1.2"
-name:         "cstruct"
-version:      "1.6.0"
 maintainer:   "anil@recoil.org"
 authors:      "Anil Madhavapeddy"
 homepage:     "https://github.com/mirage/ocaml-cstruct"


### PR DESCRIPTION
/cc @avsm these fields are usually not needed and it's confusing to keep them in sync with the rest of the metadata.