### PR TITLE
Fix tests on windows and add appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+platform:
+  - x86
+
+environment:
+  CYG_ROOT: "C:\\cygwin"
+  CYG_BASH: "%CYG_ROOT%\\bin\\bash -lc"
+
+install:
+  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+
+build_script:
+  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/test.sh
+++ b/test.sh
@@ -54,12 +54,12 @@ test_ounit bounds
 test basic
 test enum
 mkdir -p _build/lib_test
-ln -nsf ../../lib_test/http.cap _build/lib_test/http.cap
+cp lib_test/http.cap _build/lib_test/http.cap
 test pcap
 
 test_ppx basic
 test_ppx enum
 if [ -d _build/ppx_test ]; then
-  ln -nsf ../../lib_test/http.cap _build/ppx_test/http.cap
+  cp lib_test/http.cap _build/ppx_test/http.cap
 fi
 test_ppx pcap


### PR DESCRIPTION
The test.sh was failing only because it used symlinks; switch to `cp` instead.