### PR TITLE
Add LICENSE file (ISC)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+Copyright (c) 2012 Pierre Chambart
+Copyright (c) Christiano F. Haesbaert <haesbaert@haesbaert.org>
+Copyright (c) Citrix Inc
+Copyright (c) David Sheets <sheets@alum.mit.edu>
+Copyright (c) Drup <drupyog@zoho.com>
+Copyright (c) Hannes Mehnert <hannes@mehnert.org>
+Copyright (c) Jeremy Yallop <yallop@gmail.com>
+Copyright (c) Mindy Preston <meetup@yomimono.org>
+Copyright (c) Nicolas Ojeda Bar <n.oje.bar@gmail.com>
+Copyright (c) Richard Mortier <mort@cantab.net>
+Copyright (c) Rudi Grinberg <rudi.grinberg@gmail.com>
+Copyright (c) Thomas Gazagnaire <thomas@gazagnaire.com>
+Copyright (c) Thomas Leonard <talex5@gmail.com>
+Copyright (c) Vincent Bernardoff <vb@luminar.eu.org>
+Copyright (c) pqwy <david@numm.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
The Copyright (c) lines have been prepopulated from the commit Author fields via

- `git log | grep Author | sort | uniq`
- manual deduping where I know email addresses refer to the same person (-- this is where I removed one too many Davids)
- manual tweaking where I know someone has assigned their copyright to someone else

Fixes #61

Signed-off-by: David Scott <dave.scott@docker.com>