### PR TITLE
Ensure `make test` runs all the tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ configure:
 
 # OASIS_STOP
 
+test: setup.data build test.sh
+	$(SETUP) -test $(TESTFLAGS)
+	./test.sh
+
 JS_DIR ?= $(shell ocamlfind query cstruct)
 
 .PHONY: js-install js-uninstall

--- a/opam
+++ b/opam
@@ -30,7 +30,7 @@ build-test: [
       "--%{base-unix:enable}%-unix"
       "--enable-tests"]
   [make]
-  ["./test.sh"]
+  [make "test"]
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Before this patch there were 2 distinct test suites:

- `make test`: runs the tests from the _oasis file
- `test.sh`: runs a set of shell script based tests

The `opam` file only mentioned `test.sh`, so some of the tests were
effectively hidden from travis (.. and initially from me too)

Since the discussion on #54 says that we're phasing out `test.sh`,
this patch extends `make test` to call `test.sh` internally, and
makes the `opam` file run `make test`. This ensures that travis (and
developers) run all the tests rather than a subset. No-one need
know about the details of `test.sh`, and we can take our time to
refactor them.

Fixes #58

Signed-off-by: David Scott <dave.scott@docker.com>