### PR TITLE
Add hexdump_pp

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -336,23 +336,19 @@ let of_string ?allocator buf =
     blit_from_string buf 0 c 0 buflen;
     set_len c buflen
 
-let hexdump t =
+let hexdump_pp fmt t =
   let c = ref 0 in
   for i = 0 to len t - 1 do
-    if !c mod 16 = 0 then print_endline "";
-    printf "%.2x " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
+    Format.fprintf fmt "%.2x " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
     incr c;
-  done;
-  print_endline ""
+    if !c mod 16 = 0 then Format.pp_print_space fmt ();
+  done
+
+let hexdump = Format.printf "@\n%a@." hexdump_pp
 
 let hexdump_to_buffer buf t =
-  let c = ref 0 in
-  for i = 0 to len t - 1 do
-    if !c mod 16 = 0 then Buffer.add_char buf '\n';
-    bprintf buf "%.2x " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
-    incr c;
-  done;
-  Buffer.add_char buf '\n'
+  let f = Format.formatter_of_buffer buf in
+  Format.fprintf f "@\n%a@." hexdump_pp t
 
 let split ?(start=0) t off =
   try

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -343,6 +343,9 @@ val hexdump: t -> unit
 val hexdump_to_buffer: Buffer.t -> t -> unit
 (** [hexdump_to_buffer buf c] will append the pretty-printed hexdump
     of the cstruct [c] to the buffer [buf]. *)
+
+val hexdump_pp: Format.formatter -> t -> unit
+(** [hexdump_pp f c] pretty-prints a hexdump of [c] to [f]. *)
  
 val debug: t -> string
 (** [debug t] will print out the internal details of a cstruct such


### PR DESCRIPTION
This works better with the Logs library than using hexdump_to_buffer.
It also makes it easy to indent the hexdump.