### PR TITLE
Make create zero out the new buffer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+* Make `create` zero out the new buffer. The new `create_unsafe`
+  function can be used if you want to trade safety for speed.
+
 2.1.0 (2016-05-04):
 * Add `hexdump_pp` that uses the Format module. This works better with the
   Logs library than using `hexdump_to_buffer`, and also makes it easy to

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -88,7 +88,7 @@ let of_bigarray ?(off=0) ?len buffer =
 let to_bigarray buffer =
   Bigarray.Array1.sub buffer.buffer buffer.off buffer.len
 
-let create len =
+let create_unsafe len =
   let buffer = Bigarray.(Array1.create char c_layout len) in
   { buffer ; len ; off = 0 }
 
@@ -207,6 +207,11 @@ let equal t1 t2 = compare t1 t2 = 0
 
 (* Note that this is only safe as long as all [t]s are coherent. *)
 let memset t x = unsafe_fill_bigstring t.buffer t.off t.len x
+
+let create len =
+  let t = create_unsafe len in
+  memset t 0;
+  t
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then err_invalid_bounds "set_uint8" t i 1

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -196,6 +196,10 @@ val to_bigarray: t -> buffer
     sharing of the underlying buffer. *)
 
 val create : int -> t
+(** [create len] is a fresh cstruct of size [len] with an offset of 0,
+    filled with zero bytes. *)
+
+val create_unsafe : int -> t
 (** [create len] is a cstruct of size [len] with an offset of 0.
 
     Note that the returned cstruct will contain arbitrary data,


### PR DESCRIPTION
The API should be safe by default. The new `create_unsafe` function can be used if you want to trade safety for speed.

Fixes #30

See also: https://github.com/mirage/mirage-tcpip/pull/204