### PR TITLE
Add blit_from_bytes and of_bytes functions

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -65,6 +65,12 @@ let err_blit_from_string_src src dst =
 let err_blit_from_string_dst src dst =
   err "Cstruct.blit_from_string src=%a dst=%a dst-off=%d len=%d"
     string_t src pp_t dst
+let err_blit_from_bytes_src src dst =
+  err "Cstruct.blit_from_bytes src=%a dst=%a src-off=%d len=%d"
+    bytes_t src pp_t dst
+let err_blit_from_bytes_dst src dst =
+  err "Cstruct.blit_from_bytes src=%a dst=%a dst-off=%d len=%d"
+    bytes_t src pp_t dst
 let err_blit_to_bytes_src src dst =
   err "Cstruct.blit_to_bytes src=%a dst=%a src-off=%d len=%d"
     pp_t src bytes_t dst
@@ -149,6 +155,8 @@ external unsafe_blit_bigstring_to_bigstring : buffer -> int -> buffer -> int -> 
 
 external unsafe_blit_string_to_bigstring : string -> int -> buffer -> int -> int -> unit = "caml_blit_string_to_bigstring" "noalloc"
 
+external unsafe_blit_bytes_to_bigstring : Bytes.t -> int -> buffer -> int -> int -> unit = "caml_blit_string_to_bigstring" "noalloc"
+
 external unsafe_blit_bigstring_to_bytes : buffer -> int -> Bytes.t -> int -> int -> unit = "caml_blit_bigstring_to_string" "noalloc"
 
 external unsafe_blit_bigstring_to_string : buffer -> int -> string -> int -> int -> unit = "caml_blit_bigstring_to_string" "noalloc"
@@ -182,6 +190,14 @@ let blit_from_string src srcoff dst dstoff len =
     err_blit_from_string_dst src dst dstoff len
   else
     unsafe_blit_string_to_bigstring src srcoff dst.buffer (dst.off+dstoff) len
+
+let blit_from_bytes src srcoff dst dstoff len =
+  if len < 0 || srcoff < 0 || dstoff < 0 || Bytes.length src - srcoff < len then
+    err_blit_from_bytes_src src dst srcoff len
+  else if dst.len - dstoff < len then
+    err_blit_from_bytes_dst src dst dstoff len
+  else
+    unsafe_blit_bytes_to_bigstring src srcoff dst.buffer (dst.off+dstoff) len
 
 let blit_to_bytes src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || dstoff < 0 || src.len - srcoff < len then

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -357,6 +357,18 @@ let of_string ?allocator buf =
     blit_from_string buf 0 c 0 buflen;
     set_len c buflen
 
+let of_bytes ?allocator buf =
+  let buflen = Bytes.length buf in
+  match allocator with
+  |None ->
+    let c = create buflen in
+    blit_from_bytes buf 0 c 0 buflen;
+    c
+  |Some fn ->
+    let c = fn buflen in
+    blit_from_bytes buf 0 c 0 buflen;
+    set_len c buflen
+
 let hexdump_pp fmt t =
   let c = ref 0 in
   for i = 0 to len t - 1 do

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -216,6 +216,11 @@ val of_string: ?allocator:(int -> t) -> string -> t
     with the underlying buffer allocated by [alloc]. If [allocator] is not
     provided, [create] is used. *)
 
+val of_bytes: ?allocator:(int -> t) -> Bytes.t -> t
+(** [of_bytes ~allocator byt] is the cstruct representation of [byt],
+    with the underlying buffer allocated by [alloc]. If [allocator] is not
+    provided, [create] is used. *)
+
 (** {2 Comparison } *)
 
 val equal : t -> t -> bool

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -295,6 +295,15 @@ val blit_from_string: string -> int -> t -> int -> int -> unit
     valid substring of [src], or if [dstoff] and [len] do not
     designate a valid segment of [dst]. *)
 
+val blit_from_bytes: Bytes.t -> int -> t -> int -> int -> unit
+(** [blit_from_bytes src srcoff dst dstoff len] copies [len]
+    characters from bytes [src], starting at index [srcoff], to
+    cstruct [dst], starting at index [dstoff].
+
+    @raise Invalid_argument if [srcoff] and [len] do not designate a
+    valid subsequence of [src], or if [dstoff] and [len] do not
+    designate a valid segment of [dst]. *)
+
 val blit_to_bytes: t -> int -> Bytes.t -> int -> int -> unit
 (** [blit_to_string src srcoff dst dstoff len] copies [len] characters
     from cstruct [src], starting at index [srcoff], to string [dst],


### PR DESCRIPTION
In common with the existing implementation, this relies on the representation of `bytes` and `string` being the same.

Fixes #103.