### PR TITLE
Add Cstruct.subv

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -147,6 +147,9 @@ val buffer_of_sexp : Sexplib.Sexp.t -> buffer
 (** [buffer_of_sexp s] returns a fresh memory buffer from the s-expression [s].
     [s] should have been constructed using {!sexp_of_buffer}. *)
 
+(** A Cstruct is a slice of the [buffer].  Positions/offsets to a
+    Cstruct [t] (in the functions below) are relative to that slice.
+    Thus, the byte of index 0 correspond to [t.buffer.{t.off}]. *)
 type t = private {
   buffer: buffer;
   off   : int;

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -299,7 +299,7 @@ val blit_from_string: string -> int -> t -> int -> int -> unit
     designate a valid segment of [dst]. *)
 
 val blit_to_bytes: t -> int -> Bytes.t -> int -> int -> unit
-(** [blit_to_string src srcoff dst dstoff len] copies [len] characters
+(** [blit_to_bytes src srcoff dst dstoff len] copies [len] characters
     from cstruct [src], starting at index [srcoff], to string [dst],
     starting at index [dstoff].
 

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -448,6 +448,15 @@ val fillv: src:t list -> dst:t -> int * t list
  * Returns the number of bytes copied and the remaining data from [src], if any.
  * This is useful if you want buffer data into fixed-sized chunks. *)
 
+val subv : t list -> int -> int -> t list
+(** [subv ts off len] returns the range [off] ... [ofs + len - 1]
+    where the indexes are understood as if all Cstructs has been
+    concatenated.  This function does not create Cstructs of length 0
+    (but preserve those in the list), thus [subv ts off 0] returns the
+    empty list.
+    @raise Invalid_argument if [off] and [len] do not designate a
+    valid range. *)
+
 (** {2 Iterations} *)
 
 type 'a iter = unit -> 'a option


### PR DESCRIPTION
The function `val subv : t list -> int -> int -> t list` does for lists of `Cstruct.t` what `sub` does for a single one.
