### PR TITLE
fix opam metadata to depend on base-unix correctly as a depopt

### DIFF
--- a/opam
+++ b/opam
@@ -13,7 +13,7 @@ tags: [
 build: [
   ["./configure"
       "--prefix" prefix
-      "--%{lwt:enable}%-lwt"
+      "--%{lwt+base-unix:enable}%-lwt"
       "--%{ppx_tools:enable}%-ppx"
       "--%{async:enable}%-async"
       "--%{base-unix:enable}%-unix"]
@@ -49,6 +49,7 @@ depopts: [
   "ppx_tools"
   "async"
   "lwt"
+  "base-unix"
 ]
 available: [ocaml-version >= "4.02.3"]
 depexts: [


### PR DESCRIPTION
Lwt.unix is only available if base-unix is installed, so this
should also follow the same constraints