### PR TITLE
README: Use SVG build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,4 @@ The representation of the Sexp is the string representation of the enum.
 
 Please see the `ppx_test/` directory for more in-depth examples.
 
-[![Build Status](https://travis-ci.org/mirage/ocaml-cstruct.png)](https://travis-ci.org/mirage/ocaml-cstruct)
+[![Build Status](https://travis-ci.org/mirage/ocaml-cstruct.svg)](https://travis-ci.org/mirage/ocaml-cstruct)


### PR DESCRIPTION
This very simple change makes the build badge easier to read. Because SVG is shinier.