### PR TITLE
Expose pointer to Cstruct data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,15 @@ clean:
 test:
 	jbuilder runtest
 
+install:
+	jbuilder install
+
+js-install:
+	# whatever
+
+js-uninstall:
+	# whatever
+
 REPO=../../mirage/opam-repository
 PACKAGES=$(REPO)/packages
 # until we have https://github.com/ocaml/opam-publish/issues/38

--- a/configure
+++ b/configure
@@ -1,0 +1,1 @@
+/bin/true

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -153,6 +153,9 @@ let add_len t len =
   if len < 0 || not (check_bounds t (t.off+len)) then err_add_len t len
   else { t with len }
 
+external unsafe_get_pointer : buffer -> int option = "caml_get_pointer"
+
+let get_pointer x = unsafe_get_pointer x.buffer
 
 external unsafe_blit_bigstring_to_bigstring : buffer -> int -> buffer -> int -> int -> unit = "caml_blit_bigstring_to_bigstring" "noalloc"
 

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -327,6 +327,10 @@ val blit_to_string: t -> int -> Bytes.t -> int -> int -> unit
 val memset: t -> int -> unit
 (** [memset t x] sets all the bytes of [t] to [x land 0xff]. *)
 
+val get_pointer: t -> int option
+(** [get_pointer t] returns the memory pointer to the data contained in [t].
+    For use with FFI and similar where you need to reference the buffer directly. *)
+
 val len: t -> int
 (** Returns the length of the current cstruct view.  Note that this
     length is potentially smaller than the actual size of the underlying

--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -27,6 +27,29 @@
 #include <caml/bigarray.h>
 
 CAMLprim value
+caml_get_pointer(value val_buf){
+  // val_buf should be a struct caml_ba_array (aka Cstruct.t.buffer)
+  // return: int option
+  struct caml_ba_array * bigarr_buf = Caml_ba_array_val(val_buf);
+
+
+  if ((CAML_BA_LAYOUT_MASK & bigarr_buf->flags) != CAML_BA_C_LAYOUT
+      || NULL != bigarr_buf->proxy)
+  {
+      // return None
+      return(Val_int(0));
+  }
+
+  value v = Val_long( (uintptr_t) Caml_ba_data_val(val_buf)) ;
+
+  CAMLparam1( v ) ;
+  CAMLlocal1( some ) ;
+  some = caml_alloc(1, 0);
+  Store_field( some, 0, v );
+  CAMLreturn( some );
+}
+
+CAMLprim value
 caml_blit_bigstring_to_string(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
 {
   memcpy(String_val(val_buf2) + Long_val(val_ofs2),


### PR DESCRIPTION
I needed this to talk to external C code from MirageOS.
This functionality already exists in Ctypes, but unfortunately that didn't seem to compile for me.
