### PR TITLE
check_alignment: Fix crash when alignment == 0

### DIFF
--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -76,5 +76,9 @@ caml_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment
 {
   uint64_t address = (uint64_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
   int alignment = Int_val(val_alignment);
+
+  if (0 >= alignment) // Avoid division by zero or % on negative ints
+    return Val_bool(0);
+
   return Val_bool(address % alignment == 0);
 }


### PR DESCRIPTION
Fixes https://github.com/mirage/ocaml-cstruct/issues/140

I believe this should be done in OCaml, and that https://github.com/mirage/ocaml-cstruct/pull/141 makes that possible (note that the code below handles negative ints differently):
```ocaml
let check_alignment buf alignment : bool =
  match Cstruct.get_pointer buf with
  | None -> false
  | Some ptr -> try ptr mod alignment = 0 with Division_by_zero -> false
```