### PR TITLE
Problem chaining cstruct.ppx with lwt.ppx in jbuilder

### DIFF
--- a/reproducer/Makefile
+++ b/reproducer/Makefile
@@ -1,0 +1,2 @@
+build:
+	jbuilder build example.cmx

--- a/reproducer/example.ml
+++ b/reproducer/example.ml
@@ -1,0 +1,6 @@
+[%%cstruct type foo = {
+  magic: uint8_t [@len 16];
+}[@@little_endian]]
+
+let%lwt foo = Lwt.return ()
+

--- a/reproducer/jbuild
+++ b/reproducer/jbuild
@@ -1,0 +1,8 @@
+(jbuild_version 1)
+
+(library
+ ((name        example)
+  (preprocess (pps (lwt.ppx cstruct.ppx)))
+  (libraries (cstruct lwt))
+  ))
+


### PR DESCRIPTION
The PR contains a small test case to reproduce the bug.

Use

    opam pin add lwt https://github.com/andrewray/lwt.git#jbuild

to install a jbuilder-compatible lwt.

This works with cstruct 2.4.1.