### PR TITLE
ppx_cstruct: remove standalone.ml

### DIFF
--- a/ppx/standalone.ml
+++ b/ppx/standalone.ml
@@ -1,2 +1,0 @@
-include Ppx_cstruct
-let () = Migrate_parsetree.Driver.run_main ()


### PR DESCRIPTION
@diml pointed out that this module is running the ocaml-migrate-parsetree entrypoint and is preventing use of multiple sequential ppx rewriters like

  `(pps (ppx_cstruct ppx_sexp_conv))`

Signed-off-by: David Scott <dave@recoil.org>