### PR TITLE
Jbuilder fixes for Async

### DIFF
--- a/async/async_cstruct.ml
+++ b/async/async_cstruct.ml
@@ -15,7 +15,8 @@
  *)
 
 open Core
-open Async
+open Async_unix
+open Async_kernel
 
 let to_bigsubstring t =
   Bigsubstring.create 

--- a/async/async_cstruct.ml
+++ b/async/async_cstruct.ml
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 let to_bigsubstring t =
   Bigsubstring.create 

--- a/async/async_cstruct.ml
+++ b/async/async_cstruct.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Core
+open Core_kernel
 open Async_unix
 open Async_kernel
 

--- a/async/async_cstruct.mli
+++ b/async/async_cstruct.mli
@@ -14,8 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 val to_bigsubstring : Cstruct.t -> Bigsubstring.t
 val of_bigsubstring : Bigsubstring.t -> Cstruct.t

--- a/async/async_cstruct.mli
+++ b/async/async_cstruct.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-open Core
+open Core_kernel
 open Async_unix
 open Async_kernel
 

--- a/async/async_cstruct.mli
+++ b/async/async_cstruct.mli
@@ -15,7 +15,8 @@
  *)
 
 open Core
-open Async
+open Async_unix
+open Async_kernel
 
 val to_bigsubstring : Cstruct.t -> Bigsubstring.t
 val of_bigsubstring : Bigsubstring.t -> Cstruct.t

--- a/async/jbuild
+++ b/async/jbuild
@@ -2,4 +2,4 @@
  ((name async_cstruct)
   (wrapped false)
   (public_name cstruct-async)
-  (libraries (cstruct async async_unix))))
+  (libraries (cstruct async_kernel async_unix))))

--- a/async/jbuild
+++ b/async/jbuild
@@ -1,4 +1,5 @@
 (library
  ((name async_cstruct)
   (wrapped false)
-  (libraries (cstruct async.unix))))
+  (public_name cstruct-async)
+  (libraries (cstruct async async_unix))))

--- a/async/jbuild
+++ b/async/jbuild
@@ -2,4 +2,4 @@
  ((name async_cstruct)
   (wrapped false)
   (public_name cstruct-async)
-  (libraries (cstruct async_kernel async_unix))))
+  (libraries (core_kernel cstruct async_kernel async_unix))))

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -16,6 +16,7 @@ depends: [
   "jbuilder" {build & >="1.0+beta7"}
   "async_kernel"
   "async_unix"
+  "core_kernel"
   "cstruct" 
 ]
 available: [ocaml-version >= "4.02.3"]

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
-  "async"
+  "async_kernel"
   "async_unix"
   "cstruct" 
 ]

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -14,6 +14,7 @@ build: [
 ]
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
+  "async"
   "async_unix"
   "cstruct" 
 ]


### PR DESCRIPTION
The ability to build the async variant of the library seems to have been lost during the switch from Oasis to Jbuilder. This pull request restores that functionality.

* Add `public_name` field to `async/jbuilder`

* Replace `Core.Std` and `Async.Std` with `Core` and `Async` respectively in `async/async_cstruct.{ml,mli}` to eliminate deprecated warnings

* Add `async` as dependency in `cstruct-async.opam`