### PR TITLE
Fix an arithmetic overflow bug (lenv, copyv)

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -449,11 +449,14 @@ end
 (** {2 List of buffers} *)
 
 val lenv: t list -> int
-(** [lenv cstrs] is the combined length of all cstructs in [cstrs]. *)
+(** [lenv cstrs] is the combined length of all cstructs in [cstrs].
+    @raise Invalid_argument if computing the sum overflows. *)
 
 val copyv: t list -> string
 (** [copyv cstrs] is the string representation of the concatenation of
-    all cstructs in [cstrs]. *)
+    all cstructs in [cstrs].
+    @raise Invalid_argument if the length of the result would
+    exceed [Sys.max_string_length]. *)
 
 val fillv: src:t list -> dst:t -> int * t list
 (** [fillv ~src ~dst] copies from [src] to [dst] until [src] is exhausted or [dst] is full.

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -328,6 +328,24 @@ let test_view_bounds_too_small_get_le64 () =
   with
     Invalid_argument _ -> ()
 
+let test_lenv_overflow () =
+  if Sys.word_size = 32 then
+    let b = Cstruct.create max_int and c = Cstruct.create 3 in
+    try
+      let _ = Cstruct.lenv [b; b; c] in
+      failwith "test_lenv_overflow"
+    with
+      Invalid_argument _ -> ()
+
+let test_copyv_overflow () =
+  if Sys.word_size = 32 then
+    let b = Cstruct.create max_int and c = Cstruct.create 3 in
+    try
+      let _ = Cstruct.copyv [b; b; c] in
+      failwith "test_copyv_overflow"
+    with
+      Invalid_argument _ -> ()
+
 (* Steamroll over a buffer and a contained subview, checking that only the
  * contents of the subview is visible. *)
 let test_subview_containment_get_char,
@@ -438,6 +456,8 @@ let _ =
     "test_view_bounds_too_small_get_le16"  >:: test_view_bounds_too_small_get_le16;
     "test_view_bounds_too_small_get_le32"  >:: test_view_bounds_too_small_get_le32;
     "test_view_bounds_too_small_get_le64"  >:: test_view_bounds_too_small_get_le64;
+    "test_lenv_overflow" >:: test_lenv_overflow;
+    "test_copyv_overflow" >:: test_copyv_overflow;
     "test_subview_containment_get_char" >:: test_subview_containment_get_char;
     "test_subview_containment_get_8"    >:: test_subview_containment_get_8;
     "test_subview_containment_get_be16" >:: test_subview_containment_get_be16;


### PR DESCRIPTION
Modular arithmetic strikes again.

Here's a demonstration on a 32-bit system.

Before:

```ocaml
# let b = Cstruct.create max_int and c = Cstruct.create 3 ;;
val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1073741823}
val c : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
# Cstruct.lenv [b; b; c];;
- : int = 1
# Cstruct.copyv [b; b; c];;
Segmentation fault
```

After:

```ocaml
# let b = Cstruct.create max_int and c = Cstruct.create 3 ;;
val b : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 1073741823}
val c : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 3}
# Cstruct.lenv [b; b; c];;
Exception: Invalid_argument "Cstruct.lenv".
# Cstruct.copyv [b; b; c];;
Exception: Invalid_argument "Cstruct.copyv".
```