### PR TITLE
Reject negative destination offsets in 'blit'

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -169,7 +169,7 @@ let copy src srcoff len =
 let blit src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || src.len - srcoff < len then
     err_blit_src src dst srcoff len
-  else if dst.len - dstoff < len then
+  else if dstoff < 0 || dst.len - dstoff < len then
     err_blit_dst src dst dstoff len
   else
     unsafe_blit_bigstring_to_bigstring src.buffer (src.off+srcoff) dst.buffer

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -222,6 +222,14 @@ let test_blit_dst_offset_too_small () =
     failwith "test_blit_dst_offset_too_small"
   with Invalid_argument _ -> ()
 
+let test_blit_dst_offset_negative () =
+  let x = Cstruct.create 1 in
+  let y = Cstruct.create 1 in
+  try
+    Cstruct.blit x 0 y (-1) 1;
+    failwith "test_blit_dst_offset_negative"
+  with Invalid_argument _ -> ()
+
 let test_blit_len_too_big () =
   let x = Cstruct.create 1 in
   let y = Cstruct.create 2 in
@@ -426,6 +434,7 @@ let _ =
     "test blit offset too small" >:: test_blit_offset_too_small;
     "test blit dst offset too big" >:: test_blit_dst_offset_too_big;
     "test blit dst offset too small" >:: test_blit_dst_offset_too_small;
+    "test blit dst offset negative" >:: test_blit_dst_offset_negative;
     "test blit len too big" >:: test_blit_len_too_big;
     "test blit len too big2" >:: test_blit_len_too_big2;
     "test blit len too small" >:: test_blit_len_too_small;


### PR DESCRIPTION
Before:

```
# Cstruct.blit (Cstruct.create 0xf) 0 (Cstruct.create 0xf) (-0xf) 0xf;;
*** Error in `/home/jeremy/.opam/4.04.2/bin/ocamlrun': free(): invalid next size (fast): 0x0000561b7e0b0470 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x70bcb)[0x7f10fe2f9bcb]
/lib/x86_64-linux-gnu/libc.so.6(+0x76f96)[0x7f10fe2fff96]
[...]
```

After:

```
# Cstruct.blit (Cstruct.create 0xf) 0 (Cstruct.create 0xf) (-0xf) 0xf;;
Exception:
Invalid_argument
 "Cstruct.blit src=[0,15](15) dst=[0,15](15) dst-off=-15 len=15".
```