### PR TITLE
Windows fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,14 @@ platform:
   - x86
 
 environment:
-  FORK_USER: ocaml
-  FORK_BRANCH: master
-  PACKAGE: cstruct
-  CYG_ROOT: C:\cygwin64
+  global:
+    FORK_USER: ocaml
+    FORK_BRANCH: master
+    CYG_ROOT: C:\cygwin64
+    PACKAGE: cstruct
+  matrix:
+    - OPAM_SWITCH: 4.05.0+msvc32c
+    - OPAM_SWITCH: 4.04.2+mingw64c
 
 install:
   - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/$env:FORK_USER/ocaml-ci-scripts/$env:FORK_BRANCH/appveyor-install.ps1"))

--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -15,9 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <stdlib.h>
-#include <errno.h>
 #include <string.h>
 #include <stdint.h>
 

--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -74,7 +74,7 @@ caml_fill_bigstring(value val_buf, value val_ofs, value val_len, value val_byte)
 CAMLprim value
 caml_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment)
 {
-  uint64_t address = (uint64_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
+  uint64_t address = (uint64_t) ((char*)Caml_ba_data_val(val_buf) + Long_val(val_ofs));
   int alignment = Int_val(val_alignment);
   return Val_bool(address % alignment == 0);
 }


### PR DESCRIPTION
- pointer arithmetic on `void *` is not valid, although accepted by gcc/clang and most other compilers - but not msvc.
- `<sys/param.h>` is not available on Windows. Mingw provides a dummy header, but msvc doesn't. It's not needed anyway, even on *nix. So I removed it together with other unused header files.
