### PR TITLE
check_alignment: extract the alignment as a uintnat, not an int.

### DIFF
--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -75,6 +75,6 @@ CAMLprim value
 caml_check_alignment_bigstring(value val_buf, value val_ofs, value val_alignment)
 {
   uint64_t address = (uint64_t) (Caml_ba_data_val(val_buf) + Long_val(val_ofs));
-  int alignment = Int_val(val_alignment);
+  uintnat alignment = Unsigned_long_val(val_alignment);
   return Val_bool(address % alignment == 0);
 }


### PR DESCRIPTION
Spotted while reviewing #170.

Before:

```ocaml
# Cstruct.(check_alignment (create 1) 4294967296);;
Floating point exception
```

After:

```ocaml
# Cstruct.(check_alignment (create 1) 4294967296);;
- : bool = false
```