### PR TITLE
hexdump_pp: Respect indentation of parent boxes

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -371,10 +371,12 @@ let of_bytes ?allocator buf =
     set_len c buflen
 
 let hexdump_pp fmt t =
+  Format.pp_open_box fmt 0 ;
   for i = 0 to len t - 1 do
-    Format.fprintf fmt "%.2x " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
-    if i mod 16 = 15 then Format.pp_print_space fmt ();
-  done
+    Format.fprintf fmt "%.2x@ " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
+    if i mod 16 = 15 then Format.pp_force_newline fmt ();
+  done ;
+  Format.pp_close_box fmt ()
 
 let hexdump = Format.printf "@\n%a@." hexdump_pp
 

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -374,7 +374,10 @@ let hexdump_pp fmt t =
   Format.pp_open_box fmt 0 ;
   for i = 0 to len t - 1 do
     Format.fprintf fmt "%.2x@ " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
-    if i mod 16 = 15 then Format.pp_force_newline fmt ();
+    match i mod 16 with
+    | 15 -> Format.pp_force_newline fmt ()
+    |  7 -> Format.pp_print_space fmt ()
+    |  _ -> ()
   done ;
   Format.pp_close_box fmt ()
 


### PR DESCRIPTION
This wraps `hexdump_pp` output in a box, making it respect the parent box' indentation:
```
utop # Format.printf "yolo: %a" Cstruct.hexdump_pp (Cstruct.create 100) ;;
yolo: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                           00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                           00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00                                           00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
      00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
      00 00 00 00 - : unit = ()
```

the old behavior was to output:
```
utop # Format.printf "yolo: %a" Cstruct.hexdump_pp (Cstruct.create 100) ;;
yolo: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 - : unit = ()
```

I experimented with getting rid of the `if i mod 16 = ...` block by using `Format.pp_set_margin`, but ran into this (bug?): https://gist.github.com/cfcs/b39f0fa96a96235e41ff382eca8c3b86

Edit: It also changes the behavior when the lines are too small to print 16 octets to this (I couldn't see an obvious way to determine how many chars are available in the current line to print the same amount of octets on all lines, but I feel this is more readable in any case):
```
utop # Format.printf "yolo: %a" Cstruct.hexdump_pp (Cstruct.create 100) ;;
yolo: 00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00
      00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00              
      00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00 
      00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00 
      00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00 
      00 00 00 00 00 00 00 00 00 00
      00 00 00 00 00 00 
      00 00 00 00 - : unit = ()
```

The old behavior was:
```
utop # Format.printf "yolo: %a" Cstruct.hexdump_pp (Cstruct.create 100) ;;
yolo: 00 00 00 00 00 00 00 00 00 0
0 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00
00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00
00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00
00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00
00 00 00 00 00 00 00 00 00 00 00 0
0 00 00 00
00 00 00 00 - : unit = ()
```

ping @avsm 