### PR TITLE
retire ocplib-endian.  Since OCaml 4.01 the primitives are part of Bigarray

### DIFF
--- a/cstruct.opam
+++ b/cstruct.opam
@@ -16,7 +16,6 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "jbuilder" {build & >="1.0+beta10"}
-  "ocplib-endian"
   "sexplib"
   "base-bytes"
   "ounit" {test}

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -223,74 +223,82 @@ let create len =
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then err_invalid_bounds "set_uint8" t i 1
-  else EndianBigstring.BigEndian.set_int8 t.buffer (t.off+i) c
+  else Bigarray.Array1.set t.buffer (t.off+i) (Char.unsafe_chr c)
 
 let set_char t i c =
   if i >= t.len || i < 0 then err_invalid_bounds "set_char" t i 1
-  else EndianBigstring.BigEndian.set_char t.buffer (t.off+i) c
+  else Bigarray.Array1.set t.buffer (t.off+i) c
 
 let get_uint8 t i =
   if i >= t.len || i < 0 then err_invalid_bounds "get_uint8" t i 1
-  else EndianBigstring.BigEndian.get_uint8 t.buffer (t.off+i)
+  else Char.code (Bigarray.Array1.get t.buffer (t.off+i))
 
 let get_char t i =
   if i >= t.len || i < 0 then err_invalid_bounds "get_char" t i 1
-  else EndianBigstring.BigEndian.get_char t.buffer (t.off+i)
+  else Bigarray.Array1.get t.buffer (t.off+i)
+
+
+external ba_set_int16 : buffer -> int -> uint16 -> unit = "caml_ba_uint8_set16"
+external ba_set_int32 : buffer -> int -> uint32 -> unit = "caml_ba_uint8_set32"
+external ba_set_int64 : buffer -> int -> uint64 -> unit = "caml_ba_uint8_set64"
+external ba_get_int16 : buffer -> int -> uint16 = "caml_ba_uint8_get16"
+external ba_get_int32 : buffer -> int -> uint32 = "caml_ba_uint8_get32"
+external ba_get_int64 : buffer -> int -> uint64 = "caml_ba_uint8_get64"
+
+external swap16 : int -> int = "%bswap16"
+external swap32 : int32 -> int32 = "%bswap_int32"
+external swap64 : int64 -> int64 = "%bswap_int64"
 
 module BE = struct
-  include EndianBigstring.BigEndian
-
   let set_uint16 t i c =
     if (i+2) > t.len || i < 0 then err_invalid_bounds "BE.set_uint16" t i 2
-    else set_int16 t.buffer (t.off+i) c
+    else ba_set_int16 t.buffer (t.off+i) (swap16 c)
 
   let set_uint32 t i c =
     if (i+4) > t.len || i < 0 then err_invalid_bounds "BE.set_uint32" t i 4
-    else set_int32 t.buffer (t.off+i) c
+    else ba_set_int32 t.buffer (t.off+i) (swap32 c)
 
   let set_uint64 t i c =
     if (i+8) > t.len || i < 0 then err_invalid_bounds "BE.set_uint64" t i 8
-    else set_int64 t.buffer (t.off+i) c
+    else ba_set_int64 t.buffer (t.off+i) (swap64 c)
 
   let get_uint16 t i =
     if (i+2) > t.len || i < 0 then err_invalid_bounds "BE.get_uint16" t i 2
-    else get_uint16 t.buffer (t.off+i)
+    else swap16 (ba_get_int16 t.buffer (t.off+i))
 
   let get_uint32 t i =
     if (i+4) > t.len || i < 0 then err_invalid_bounds "BE.get_uint32" t i 4
-    else get_int32 t.buffer (t.off+i)
+    else swap32 (ba_get_int32 t.buffer (t.off+i))
 
   let get_uint64 t i =
     if (i+8) > t.len || i < 0 then err_invalid_bounds "BE.uint64" t i 8
-    else get_int64 t.buffer (t.off+i)
+    else swap64 (ba_get_int64 t.buffer (t.off+i))
 end
 
 module LE = struct
-  include EndianBigstring.LittleEndian
-
   let set_uint16 t i c =
     if (i+2) > t.len || i < 0 then err_invalid_bounds "LE.set_uint16" t i 2
-    else set_int16 t.buffer (t.off+i) c
+    else ba_set_int16 t.buffer (t.off+i) c
 
   let set_uint32 t i c =
     if (i+4) > t.len || i < 0 then err_invalid_bounds "LE.set_uint32" t i 4
-    else set_int32 t.buffer (t.off+i) c
+    else ba_set_int32 t.buffer (t.off+i) c
 
   let set_uint64 t i c =
     if (i+8) > t.len || i < 0 then err_invalid_bounds "LE.set_uint64" t i 8
-    else set_int64 t.buffer (t.off+i) c
+    else ba_set_int64 t.buffer (t.off+i) c
 
   let get_uint16 t i =
     if (i+2) > t.len || i < 0 then err_invalid_bounds "LE.get_uint16" t i 2
-    else get_uint16 t.buffer (t.off+i)
+    else ba_get_int16 t.buffer (t.off+i)
 
   let get_uint32 t i =
     if (i+4) > t.len || i < 0 then err_invalid_bounds "LE.get_uint32" t i 4
-    else get_int32 t.buffer (t.off+i)
+    else ba_get_int32 t.buffer (t.off+i)
 
   let get_uint64 t i =
     if (i+8) > t.len || i < 0 then err_invalid_bounds "LE.get_uint64" t i 8
-    else get_int64 t.buffer (t.off+i)
+    else ba_get_int64 t.buffer (t.off+i)
 end
 
 let len t =

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -249,56 +249,52 @@ external swap16 : int -> int = "%bswap16"
 external swap32 : int32 -> int32 = "%bswap_int32"
 external swap64 : int64 -> int64 = "%bswap_int64"
 
+let set_uint16 swap p t i c =
+  if (i+2) > t.len || i < 0 then err_invalid_bounds (p ^ ".set_uint16") t i 2
+  else ba_set_int16 t.buffer (t.off+i) (if swap then swap16 c else c)
+
+let set_uint32 swap p t i c =
+  if (i+4) > t.len || i < 0 then err_invalid_bounds (p ^ ".set_uint32") t i 4
+  else ba_set_int32 t.buffer (t.off+i) (if swap then swap32 c else c)
+
+let set_uint64 swap p t i c =
+  if (i+8) > t.len || i < 0 then err_invalid_bounds (p ^ ".set_uint64") t i 8
+  else ba_set_int64 t.buffer (t.off+i) (if swap then swap64 c else c)
+
+let get_uint16 swap p t i =
+  if (i+2) > t.len || i < 0 then err_invalid_bounds (p ^ ".get_uint16") t i 2
+  else
+    let r = ba_get_int16 t.buffer (t.off+i) in
+    if swap then swap16 r else r
+
+let get_uint32 swap p t i =
+  if (i+4) > t.len || i < 0 then err_invalid_bounds (p ^ ".get_uint32") t i 4
+  else
+    let r = ba_get_int32 t.buffer (t.off+i) in
+    if swap then swap32 r else r
+
+let get_uint64 swap p t i =
+  if (i+8) > t.len || i < 0 then err_invalid_bounds (p ^ "uint64") t i 8
+  else
+    let r = ba_get_int64 t.buffer (t.off+i) in
+    if swap then swap64 r else r
+
 module BE = struct
-  let set_uint16 t i c =
-    if (i+2) > t.len || i < 0 then err_invalid_bounds "BE.set_uint16" t i 2
-    else ba_set_int16 t.buffer (t.off+i) (swap16 c)
-
-  let set_uint32 t i c =
-    if (i+4) > t.len || i < 0 then err_invalid_bounds "BE.set_uint32" t i 4
-    else ba_set_int32 t.buffer (t.off+i) (swap32 c)
-
-  let set_uint64 t i c =
-    if (i+8) > t.len || i < 0 then err_invalid_bounds "BE.set_uint64" t i 8
-    else ba_set_int64 t.buffer (t.off+i) (swap64 c)
-
-  let get_uint16 t i =
-    if (i+2) > t.len || i < 0 then err_invalid_bounds "BE.get_uint16" t i 2
-    else swap16 (ba_get_int16 t.buffer (t.off+i))
-
-  let get_uint32 t i =
-    if (i+4) > t.len || i < 0 then err_invalid_bounds "BE.get_uint32" t i 4
-    else swap32 (ba_get_int32 t.buffer (t.off+i))
-
-  let get_uint64 t i =
-    if (i+8) > t.len || i < 0 then err_invalid_bounds "BE.uint64" t i 8
-    else swap64 (ba_get_int64 t.buffer (t.off+i))
+  let set_uint16 t i c = set_uint16 (not Sys.big_endian) "BE" t i c
+  let set_uint32 t i c = set_uint32 (not Sys.big_endian) "BE" t i c
+  let set_uint64 t i c = set_uint64 (not Sys.big_endian) "BE" t i c
+  let get_uint16 t i = get_uint16 (not Sys.big_endian) "BE" t i
+  let get_uint32 t i = get_uint32 (not Sys.big_endian) "BE" t i
+  let get_uint64 t i = get_uint64 (not Sys.big_endian) "BE" t i
 end
 
 module LE = struct
-  let set_uint16 t i c =
-    if (i+2) > t.len || i < 0 then err_invalid_bounds "LE.set_uint16" t i 2
-    else ba_set_int16 t.buffer (t.off+i) c
-
-  let set_uint32 t i c =
-    if (i+4) > t.len || i < 0 then err_invalid_bounds "LE.set_uint32" t i 4
-    else ba_set_int32 t.buffer (t.off+i) c
-
-  let set_uint64 t i c =
-    if (i+8) > t.len || i < 0 then err_invalid_bounds "LE.set_uint64" t i 8
-    else ba_set_int64 t.buffer (t.off+i) c
-
-  let get_uint16 t i =
-    if (i+2) > t.len || i < 0 then err_invalid_bounds "LE.get_uint16" t i 2
-    else ba_get_int16 t.buffer (t.off+i)
-
-  let get_uint32 t i =
-    if (i+4) > t.len || i < 0 then err_invalid_bounds "LE.get_uint32" t i 4
-    else ba_get_int32 t.buffer (t.off+i)
-
-  let get_uint64 t i =
-    if (i+8) > t.len || i < 0 then err_invalid_bounds "LE.get_uint64" t i 8
-    else ba_get_int64 t.buffer (t.off+i)
+  let set_uint16 t i c = set_uint16 Sys.big_endian "LE" t i c
+  let set_uint32 t i c = set_uint32 Sys.big_endian "LE" t i c
+  let set_uint64 t i c = set_uint64 Sys.big_endian "LE" t i c
+  let get_uint16 t i = get_uint16 Sys.big_endian "LE" t i
+  let get_uint32 t i = get_uint32 Sys.big_endian "LE" t i
+  let get_uint64 t i = get_uint64 Sys.big_endian "LE" t i
 end
 
 let len t =

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -2,7 +2,7 @@
   ((name cstruct)
    (public_name cstruct)
    (modules (cstruct))
-   (libraries (sexplib ocplib-endian ocplib-endian.bigstring))
+   (libraries (sexplib))
    (c_names (cstruct_stubs))
 ))
 (jbuild_version 1)


### PR DESCRIPTION
in the same spirit as https://github.com/inhabitedtype/faraday/pull/24 (thanks @seliopou) we can directly use the primitives provided by the OCaml runtime (since 4.01, https://caml.inria.fr/mantis/view.php?id=5771 -- cstruct is only available on `>= 4.02.3`).

Why?  Well, less dependencies are always better.  ocplib-endian is additionally LGPL licensed (see https://github.com/OCamlPro/ocplib-endian/blob/master/COPYING.txt) - thus pretty deep down in our dependency chain a not very permissively licensed library.

~~What do we loose? big endian support (which AFAICT hasn't been used anyways, or has it?) -- it can be re-added by either some preprocessing (cpp0?) or by dynamic checks for `Sys.big_endian`.  I don't know enough about cpp0 do go that way, but I can add the dynamic `Sys.big_endian` checks if this is desired.~~

EDIT: I added `Sys.big_endian` tests, performance could be improved using a preprocessor (but since ocplib as well uses runtime checks, there's no performance regression in here)