### PR TITLE
add "to_bytes : t -> bytes".  the reasoning behind this is that

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -339,12 +339,15 @@ let fillv ~src ~dst =
   aux dst 0 src
 
 
-let to_string t =
+let to_bytes t =
   let sz = len t in
   let b = Bytes.create sz in
   unsafe_blit_bigstring_to_bytes t.buffer t.off b 0 sz;
+  b
+
+let to_string t =
   (* The following call is safe, since b is not visible elsewhere. *)
-  Bytes.unsafe_to_string b
+  Bytes.unsafe_to_string (to_bytes t)
 
 let of_string ?allocator buf =
   let buflen = String.length buf in

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -346,7 +346,8 @@ let to_bytes t =
   b
 
 let to_string t =
-  (* The following call is safe, since b is not visible elsewhere. *)
+  (* The following call is safe, since this is the only reference to the
+     freshly-created value built by [to_bytes t]. *)
   Bytes.unsafe_to_string (to_bytes t)
 
 let of_string ?allocator buf =

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -354,6 +354,10 @@ val to_string: t -> string
 (** [to_string t] will allocate a fresh OCaml [string] and copy the
     contents of the cstruct into it, and return that string copy. *)
 
+val to_bytes: t -> bytes
+(** [to_bytes t] will allocate a fresh OCaml [bytes] and copy the
+    contents of the cstruct into it, and return that byte copy. *)
+
 (** {2 Debugging } *)
 
 val hexdump: t -> unit


### PR DESCRIPTION
(a) safe-string by default in 4.06 which demand us to separate string and bytes
(b) to_string is implemented as Bytes.to_string |> to_bytes
(c) read and write from stdlib now receive bytes
(d) user code otherwise has to: Cstruct.to_string |> Bytes.of_string (which copies)