### PR TITLE
Fix the build on OCaml 4.06.0

### DIFF
--- a/unix/jbuild
+++ b/unix/jbuild
@@ -2,4 +2,7 @@
  ((name cstruct_unix)
   (wrapped false)
   (public_name cstruct-unix)
+  ; disable the deprecated warning as we can't use Unix.map_file
+  ; yet as it was only introduced in OCaml 4.06
+  (flags (:standard -w -3))
   (libraries (cstruct unix))))


### PR DESCRIPTION
The `Bigarray.Array1.map_file` function is deprecated and we should use
`Unix.map_file` in future, however `Unix.map_file` is new in OCaml 4.06
and we still support OCaml 4.04.2.

This patch removes the deprecated warning in the `unix/` directory
as a work-around.

Signed-off-by: David Scott <dave@recoil.org>