### PR TITLE
Access the buffer via primitives

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -241,12 +241,12 @@ let get_char t i =
   else Bigarray.Array1.get t.buffer (t.off+i)
 
 
-external ba_set_int16 : buffer -> int -> uint16 -> unit = "caml_ba_uint8_set16"
-external ba_set_int32 : buffer -> int -> uint32 -> unit = "caml_ba_uint8_set32"
-external ba_set_int64 : buffer -> int -> uint64 -> unit = "caml_ba_uint8_set64"
-external ba_get_int16 : buffer -> int -> uint16 = "caml_ba_uint8_get16"
-external ba_get_int32 : buffer -> int -> uint32 = "caml_ba_uint8_get32"
-external ba_get_int64 : buffer -> int -> uint64 = "caml_ba_uint8_get64"
+external ba_set_int16 : buffer -> int -> uint16 -> unit = "%caml_bigstring_set16"
+external ba_set_int32 : buffer -> int -> uint32 -> unit = "%caml_bigstring_set32"
+external ba_set_int64 : buffer -> int -> uint64 -> unit = "%caml_bigstring_set64"
+external ba_get_int16 : buffer -> int -> uint16 = "%caml_bigstring_get16"
+external ba_get_int32 : buffer -> int -> uint32 = "%caml_bigstring_get32"
+external ba_get_int64 : buffer -> int -> uint64 = "%caml_bigstring_get64"
 
 external swap16 : int -> int = "%bswap16"
 external swap32 : int32 -> int32 = "%bswap_int32"
@@ -304,11 +304,11 @@ let len t =
   t.len
 
 (** [sum_lengths ~caller acc l] is [acc] plus the sum of the lengths
-    of the elements of [l].  Raises [Invalid_argument caller] if 
+    of the elements of [l].  Raises [Invalid_argument caller] if
     arithmetic overflows. *)
 let rec sum_lengths_aux ~caller acc = function
   | [] -> acc
-  | h :: t -> 
+  | h :: t ->
      let sum = len h + acc in
      if sum < acc then invalid_arg caller
      else sum_lengths_aux ~caller sum t


### PR DESCRIPTION
The trivial part of #194 fix -- use the primitives, not the C stubs.

This gets my bench from ~7.96s to ~2.95s, where 3.1.1 is at ~2.82s. The remaining ~5% is probably down to the swapping decision being made on every access. (Dump below.)

As an aside, manually doing the same on a bare `bigstring`, accessing via `%caml_bigstring_get64` (the bounds-checked version), and swapping with `%bswap_int64`, takes ~1.36s. Cstruct is doing waaaaaaay too much on access.

#### 3.1.1:

```ASM
000000000006acb0 <camlCstruct__get_uint64_1851>:
   6acb0:	48 83 ec 18          	sub    $0x18,%rsp
   6acb4:	48 8b 78 10          	mov    0x10(%rax),%rdi
   6acb8:	48 89 de             	mov    %rbx,%rsi
   6acbb:	48 83 c6 10          	add    $0x10,%rsi
   6acbf:	48 39 fe             	cmp    %rdi,%rsi
   6acc2:	7f 70                	jg     6ad34 <camlCstruct__get_uint64_1851+0x84>
   6acc4:	48 83 fb 01          	cmp    $0x1,%rbx
   6acc8:	7c 6a                	jl     6ad34 <camlCstruct__get_uint64_1851+0x84>
   6acca:	48 8b 78 08          	mov    0x8(%rax),%rdi
   6acce:	48 8d 5c 1f ff       	lea    -0x1(%rdi,%rbx,1),%rbx
   6acd3:	48 8b 38             	mov    (%rax),%rdi
   6acd6:	49 83 ef 18          	sub    $0x18,%r15
   6acda:	48 8d 05 bf 2f 32 00 	lea    0x322fbf(%rip),%rax        # 38dca0 <caml_young_limit>
   6ace1:	4c 3b 38             	cmp    (%rax),%r15
   6ace4:	0f 82 85 00 00 00    	jb     6ad6f <camlCstruct__get_uint64_1851+0xbf>
   6acea:	49 8d 47 08          	lea    0x8(%r15),%rax
   6acee:	48 c7 40 f8 ff 08 00 	movq   $0x8ff,-0x8(%rax)
   6acf5:	00 
   6acf6:	48 8d 35 c3 e9 31 00 	lea    0x31e9c3(%rip),%rsi        # 3896c0 <caml_int64_ops>
   6acfd:	48 89 30             	mov    %rsi,(%rax)
   6ad00:	48 d1 fb             	sar    %rbx
   6ad03:	48 8b 77 08          	mov    0x8(%rdi),%rsi
   6ad07:	48 8b 7f 28          	mov    0x28(%rdi),%rdi
   6ad0b:	48 83 c7 f9          	add    $0xfffffffffffffff9,%rdi
   6ad0f:	48 89 fa             	mov    %rdi,%rdx
   6ad12:	48 c1 fa 3f          	sar    $0x3f,%rdx
   6ad16:	48 83 f2 ff          	xor    $0xffffffffffffffff,%rdx
   6ad1a:	48 21 fa             	and    %rdi,%rdx
   6ad1d:	48 39 da             	cmp    %rbx,%rdx
   6ad20:	76 57                	jbe    6ad79 <camlCstruct__get_uint64_1851+0xc9>
   6ad22:	48 8b 1c 1e          	mov    (%rsi,%rbx,1),%rbx
   6ad26:	48 0f cb             	bswap  %rbx
   6ad29:	48 89 58 08          	mov    %rbx,0x8(%rax)
   6ad2d:	48 83 c4 18          	add    $0x18,%rsp
   6ad31:	c3                   	retq   
   6ad32:	66 90                	xchg   %ax,%ax
   6ad34:	48 c7 c7 11 00 00 00 	mov    $0x11,%rdi
   6ad3b:	48 89 7c 24 10       	mov    %rdi,0x10(%rsp)
   6ad40:	48 89 5c 24 08       	mov    %rbx,0x8(%rsp)
   6ad45:	48 89 04 24          	mov    %rax,(%rsp)
   6ad49:	48 8d 05 20 3a 2c 00 	lea    0x2c3a20(%rip),%rax        # 32e770 <camlCstruct__220>
   6ad50:	e8 ab ee ff ff       	callq  69c00 <camlCstruct__err_invalid_bounds_1577>
   6ad55:	48 89 c6             	mov    %rax,%rsi
   6ad58:	48 8b 04 24          	mov    (%rsp),%rax
   6ad5c:	48 8b 5c 24 08       	mov    0x8(%rsp),%rbx
   6ad61:	48 8b 7c 24 10       	mov    0x10(%rsp),%rdi
   6ad66:	48 83 c4 18          	add    $0x18,%rsp
   6ad6a:	e9 e1 e5 ff ff       	jmpq   69350 <caml_apply3>
   6ad6f:	e8 04 45 09 00       	callq  ff278 <caml_call_gc>
   6ad74:	e9 5d ff ff ff       	jmpq   6acd6 <camlCstruct__get_uint64_1851+0x26>
   6ad79:	e8 82 49 09 00       	callq  ff700 <caml_ml_array_bound_error>
   6ad7e:	66 90                	xchg   %ax,%ax
```


#### 3.2.0 + prims:
```ASM
0000000000069b70 <camlCstruct__get_uint64_1825>:
   69b70:	48 83 ec 18          	sub    $0x18,%rsp
   69b74:	48 8b 57 10          	mov    0x10(%rdi),%rdx
   69b78:	48 89 f1             	mov    %rsi,%rcx
   69b7b:	48 83 c1 10          	add    $0x10,%rcx
   69b7f:	48 39 d1             	cmp    %rdx,%rcx
   69b82:	0f 8f ac 00 00 00    	jg     69c34 <camlCstruct__get_uint64_1825+0xc4>
   69b88:	48 83 fe 01          	cmp    $0x1,%rsi
   69b8c:	0f 8c a2 00 00 00    	jl     69c34 <camlCstruct__get_uint64_1825+0xc4>
   69b92:	48 8b 1f             	mov    (%rdi),%rbx
   69b95:	48 8b 7f 08          	mov    0x8(%rdi),%rdi
   69b99:	48 8d 7c 37 ff       	lea    -0x1(%rdi,%rsi,1),%rdi
   69b9e:	48 d1 ff             	sar    %rdi
   69ba1:	48 8b 73 08          	mov    0x8(%rbx),%rsi
   69ba5:	48 8b 5b 28          	mov    0x28(%rbx),%rbx
   69ba9:	48 83 c3 f9          	add    $0xfffffffffffffff9,%rbx
   69bad:	48 89 da             	mov    %rbx,%rdx
   69bb0:	48 c1 fa 3f          	sar    $0x3f,%rdx
   69bb4:	48 83 f2 ff          	xor    $0xffffffffffffffff,%rdx
   69bb8:	48 21 da             	and    %rbx,%rdx
   69bbb:	48 39 fa             	cmp    %rdi,%rdx
   69bbe:	0f 86 c7 00 00 00    	jbe    69c8b <camlCstruct__get_uint64_1825+0x11b>
   69bc4:	48 8b 1c 3e          	mov    (%rsi,%rdi,1),%rbx
   69bc8:	48 83 f8 01          	cmp    $0x1,%rax
   69bcc:	74 36                	je     69c04 <camlCstruct__get_uint64_1825+0x94>
   69bce:	49 83 ef 18          	sub    $0x18,%r15
   69bd2:	48 8d 05 c7 f0 31 00 	lea    0x31f0c7(%rip),%rax        # 388ca0 <caml_young_limit>
   69bd9:	4c 3b 38             	cmp    (%rax),%r15
   69bdc:	0f 82 9f 00 00 00    	jb     69c81 <camlCstruct__get_uint64_1825+0x111>
   69be2:	49 8d 47 08          	lea    0x8(%r15),%rax
   69be6:	48 c7 40 f8 ff 08 00 	movq   $0x8ff,-0x8(%rax)
   69bed:	00 
   69bee:	48 8d 3d cb aa 31 00 	lea    0x31aacb(%rip),%rdi        # 3846c0 <caml_int64_ops>
   69bf5:	48 89 38             	mov    %rdi,(%rax)
   69bf8:	48 0f cb             	bswap  %rbx
   69bfb:	48 89 58 08          	mov    %rbx,0x8(%rax)
   69bff:	48 83 c4 18          	add    $0x18,%rsp
   69c03:	c3                   	retq   
   69c04:	49 83 ef 18          	sub    $0x18,%r15
   69c08:	48 8d 05 91 f0 31 00 	lea    0x31f091(%rip),%rax        # 388ca0 <caml_young_limit>
   69c0f:	4c 3b 38             	cmp    (%rax),%r15
   69c12:	72 66                	jb     69c7a <camlCstruct__get_uint64_1825+0x10a>
   69c14:	49 8d 47 08          	lea    0x8(%r15),%rax
   69c18:	48 c7 40 f8 ff 08 00 	movq   $0x8ff,-0x8(%rax)
   69c1f:	00 
   69c20:	48 8d 3d 99 aa 31 00 	lea    0x31aa99(%rip),%rdi        # 3846c0 <caml_int64_ops>
   69c27:	48 89 38             	mov    %rdi,(%rax)
   69c2a:	48 89 58 08          	mov    %rbx,0x8(%rax)
   69c2e:	48 83 c4 18          	add    $0x18,%rsp
   69c32:	c3                   	retq   
   69c33:	90                   	nop
   69c34:	48 c7 c0 11 00 00 00 	mov    $0x11,%rax
   69c3b:	48 89 44 24 10       	mov    %rax,0x10(%rsp)
   69c40:	48 89 74 24 08       	mov    %rsi,0x8(%rsp)
   69c45:	48 89 3c 24          	mov    %rdi,(%rsp)
   69c49:	48 8d 3d 58 0a 2c 00 	lea    0x2c0a58(%rip),%rdi        # 32a6a8 <camlCstruct__220>
   69c50:	48 89 d8             	mov    %rbx,%rax
   69c53:	48 89 fb             	mov    %rdi,%rbx
   69c56:	e8 05 5c 02 00       	callq  8f860 <camlPervasives__$5e_1117>
   69c5b:	e8 80 ed ff ff       	callq  689e0 <camlCstruct__err_invalid_bounds_1577>
   69c60:	48 89 c6             	mov    %rax,%rsi
   69c63:	48 8b 04 24          	mov    (%rsp),%rax
   69c67:	48 8b 5c 24 08       	mov    0x8(%rsp),%rbx
   69c6c:	48 8b 7c 24 10       	mov    0x10(%rsp),%rdi
   69c71:	48 83 c4 18          	add    $0x18,%rsp
   69c75:	e9 96 e4 ff ff       	jmpq   68110 <caml_apply3>
   69c7a:	e8 79 1d 09 00       	callq  fb9f8 <caml_call_gc>
   69c7f:	eb 83                	jmp    69c04 <camlCstruct__get_uint64_1825+0x94>
   69c81:	e8 72 1d 09 00       	callq  fb9f8 <caml_call_gc>
   69c86:	e9 43 ff ff ff       	jmpq   69bce <camlCstruct__get_uint64_1825+0x5e>
   69c8b:	e8 f0 21 09 00       	callq  fbe80 <caml_ml_array_bound_error>
```