### PR TITLE
Do not depend explicitly on deprecated ppx_driver

### DIFF
--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -21,7 +21,7 @@ depends: [
   "ounit" {test}
   "ppx_tools_versioned" {>="5.0.1"}
   "ocaml-migrate-parsetree"
-  "ppx_driver"    {test & >= "v0.9.0"}
+  ("ppx_driver"    {test & >= "v0.9.0"} | "ppxlib" { test })
   "ppx_sexp_conv" {test}
   "cstruct-unix"  {test}
 ]


### PR DESCRIPTION
To avoid having to pull in a deprecated package depend on either
`ppx_driver` or `ppxlib`, apparently the only reason we depend on it is
to ensure the version is new enough, ppx_cstruct does not require it
directly.

I kept both ppx_driver and ppxlib so that the dependency works with
older compiler versions too.

Do not put version constraints on `ppxlib`, any version is newer than
`ppx_driver`, and if the version constraint is not satisfied then opam
would fall back installing a new `ppx_driver` instead of upgrading an
existing `ppxlib`.

Tested with opam 2.0.0~rc3 and OCaml 4.06.1