### PR TITLE
avoid compiler-libs runtime dependency in ppx_cstruct

### DIFF
--- a/ppx/jbuild
+++ b/ppx/jbuild
@@ -9,6 +9,4 @@
   (preprocess (pps (ppx_tools_versioned.metaquot_404)))
   (libraries
    (ocaml-migrate-parsetree
-    ppx_tools_versioned
-    ppx_tools_versioned.metaquot_404
     bigarray))))


### PR DESCRIPTION
What I observed while demoing on stage at bornhack is a `hello.ukvm` which is rather large (>10MB), so I wondered what is in there.  Turns out, the OCaml compiler libs once again managed to find their way into all the unikernels.

After figuring out (`ocamlfind query -r <my-package>`) where this originates from, I stumbled upon `mirage-profile` which (run-)depends on `ppx_tools_versioned`.  The culprit is `ppx_cstruct`, quoting their META file:
```
# This line makes things transparent for people mixing preprocessors
# and normal dependencies
requires(-ppx_driver) = "cstruct ppx_tools_versioned"
```

I looked into other `ppx_*`  META files and discovered that the line above should only list run-time dependencies, which is here not the case.  I permutated the `ppx/jbuild` file in various combinations, and the one in this PR leads to a working `ppx_cstruct`, which does not have a run-dependency on `ppx_tools_versioned`.  Since I'm no ppx neither jbuild/dune expert, I'd appreciate comments whether this is the right way to solve this issue.

My environment: I tested OCaml 4.06.1 and 4.07.0 (on FreeBSD/amd64), using jbuilder 1.0+beta20, also dune 1.0.1 and 1.1.1 (all three of them show the same behaviour).

With this patch, `hello.ukvm` is back to 2.6MB.  A merge and release would be highly appreciated @mirage/core //cc @rgrinberg