### PR TITLE
Update opam files for 2.0 format

### DIFF
--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -1,11 +1,11 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
                "Mindy Preston" "Thomas Leonard" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
-dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
@@ -13,10 +13,18 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build & >="1.0+beta7"}
-  "async_kernel" {>="v0.9.0"}
-  "async_unix" {>="v0.9.0"}
-  "core_kernel" {>="v0.9.0"}
-  "cstruct" {>="3.0.0"}
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {build & >= "1.0+beta7"}
+  "async_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_unix" {>= "v0.9.0" & < "v0.12"}
+  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "cstruct" {>= "3.0.0"}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src: "git+https://github.com/mirage/ocaml-cstruct.git"
+}

--- a/cstruct-lwt.opam
+++ b/cstruct-lwt.opam
@@ -1,11 +1,11 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
                "Mindy Preston" "Thomas Leonard" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
-dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
@@ -13,9 +13,17 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
+  "ocaml" {>= "4.03.0"}
   "base-unix"
   "lwt"
   "cstruct"
-  "jbuilder" {build & >="1.0+beta7"}
+  "jbuilder" {build & >= "1.0+beta7"}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src: "git+https://github.com/mirage/ocaml-cstruct.git"
+}

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -1,11 +1,11 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
                "Mindy Preston" "Thomas Leonard" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
-dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
@@ -13,8 +13,16 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "jbuilder" {build & >="1.0+beta7"}
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {build & >= "1.0+beta7"}
   "base-unix"
   "cstruct"
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src: "git+https://github.com/mirage/ocaml-cstruct.git"
+}

--- a/cstruct.opam
+++ b/cstruct.opam
@@ -1,22 +1,29 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
                "Mindy Preston" "Thomas Leonard" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
-dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name] {with-test}
 ]
-build-test: ["jbuilder" "runtest" "-p" name]
-
 depends: [
-  "jbuilder" {build & >="1.0+beta10"}
-  "sexplib"
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {build & >= "1.0+beta10"}
+  "sexplib" {< "v0.12"}
   "alcotest" {test}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src: "git+https://github.com/mirage/ocaml-cstruct.git"
+}

--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -1,27 +1,34 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
                "Mindy Preston" "Thomas Leonard" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
-dev-repo:     "https://github.com/mirage/ocaml-cstruct.git"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["jbuilder" "subst" "-p" name "--name" name] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
-]
-build-test: [
-  ["jbuilder" "runtest" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "jbuilder" {build & >="1.0+beta7"}
-  "cstruct"
-  "ppx_tools_versioned" {>="5.0.1"}
+  "ocaml" {>= "4.03.0"}
+  "jbuilder" {build & >= "1.0+beta9"}
+  "cstruct" {>= "3.1.1"}
+  "ounit" {with-test}
+  "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"
-  ("ppx_driver"    {test & >= "v0.9.0"} | "ppxlib" { test })
-  "ppx_sexp_conv" {test}
-  "cstruct-unix"  {test}
+  "ppx_driver" {with-test & >= "v0.9.0"}
+  "ppx_sexp_conv" {with-test & < "v0.12"}
+  "cstruct-unix" {with-test}
 ]
-available: [ocaml-version >= "4.03.0"]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src: "git+https://github.com/mirage/ocaml-cstruct.git"
+}


### PR DESCRIPTION
Since now opam 1.2 is dead, time to update. Basically copied opam files from opam-repository and changed URL. It should fix complains from Travis too.