### PR TITLE
Remove trailing spaces in hexdump output

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -412,13 +412,22 @@ let of_hex str =
   | cs, i, _, _ -> sub cs 0 i
 
 let hexdump_pp fmt t =
+  let before fmt =
+    function
+    | 0 -> ()
+    | 8 -> Format.fprintf fmt "  ";
+    | _ -> Format.fprintf fmt " "
+  in
+  let after fmt =
+    function
+    | 15 -> Format.pp_force_newline fmt ()
+    |  _ -> ()
+  in
   Format.pp_open_box fmt 0 ;
   for i = 0 to len t - 1 do
-    Format.fprintf fmt "%.2x@ " (Char.code (Bigarray.Array1.get t.buffer (t.off+i)));
-    match i mod 16 with
-    | 15 -> Format.pp_force_newline fmt ()
-    |  7 -> Format.pp_print_space fmt ()
-    |  _ -> ()
+    let column = i mod 16 in
+    let c = Char.code (Bigarray.Array1.get t.buffer (t.off+i)) in
+    Format.fprintf fmt "%a%.2x%a" before column c after column
   done ;
   Format.pp_close_box fmt ()
 

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -420,10 +420,10 @@ let hexdump_pp fmt t =
   in
   let after fmt =
     function
-    | 15 -> Format.pp_force_newline fmt ()
+    | 15 -> Format.fprintf fmt "@;"
     |  _ -> ()
   in
-  Format.pp_open_box fmt 0 ;
+  Format.pp_open_vbox fmt 0 ;
   for i = 0 to len t - 1 do
     let column = i mod 16 in
     let c = Char.code (Bigarray.Array1.get t.buffer (t.off+i)) in

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -137,6 +137,36 @@ let check_alignment_large () =
     try let _ = check () in Alcotest.fail "alignement should raise"
     with Invalid_argument _ -> ()
 
+let test_hexdump cs expected =
+  let got = Format.asprintf "%a" Cstruct.hexdump_pp cs in
+  Alcotest.(check string) "hexdump output" expected got
+
+let hexdump_empty () =
+  test_hexdump
+    Cstruct.empty
+    ""
+
+let hexdump_small () =
+  test_hexdump
+    (Cstruct.of_hex "00010203")
+    "00 01 02 03 "
+
+let hexdump_multiline () =
+  test_hexdump
+    (Cstruct.of_hex "000102030405060708090a0b0c0d0e0f101112")
+    ( "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f \n"
+    ^ "10 11 12 ")
+
+let hexdump_aligned () =
+  test_hexdump
+    (Cstruct.of_hex "000102030405060708090a0b0c0d0e0f")
+    "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f \n"
+
+let hexdump_aligned_to_half () =
+  test_hexdump
+    (Cstruct.of_hex "0001020304050607")
+    "00 01 02 03 04 05 06 07  "
+
 let suite = [
   "fillv", [
     "fillv", `Quick, fillv
@@ -158,6 +188,13 @@ let suite = [
     "aligned to 512"  , `Quick, check_alignment 512;
     "aligned to 0"    , `Quick, check_alignment_zero;
     "aligned to large", `Quick, check_alignment_large;
+  ];
+  "hexdump", [
+    "empty", `Quick, hexdump_empty;
+    "small", `Quick, hexdump_small;
+    "multiline", `Quick, hexdump_multiline;
+    "aligned", `Quick, hexdump_aligned;
+    "aligned to half", `Quick, hexdump_aligned_to_half;
   ]
 ]
 

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -137,8 +137,8 @@ let check_alignment_large () =
     try let _ = check () in Alcotest.fail "alignement should raise"
     with Invalid_argument _ -> ()
 
-let test_hexdump cs expected =
-  let got = Format.asprintf "%a" Cstruct.hexdump_pp cs in
+let test_hexdump ?(format=("%a" : _ format4)) cs expected =
+  let got = Format.asprintf format Cstruct.hexdump_pp cs in
   Alcotest.(check string) "hexdump output" expected got
 
 let hexdump_empty () =
@@ -151,9 +151,12 @@ let hexdump_small () =
     (Cstruct.of_hex "00010203")
     "00 01 02 03"
 
+let hex_multiline =
+  Cstruct.of_hex "000102030405060708090a0b0c0d0e0f101112"
+
 let hexdump_multiline () =
   test_hexdump
-    (Cstruct.of_hex "000102030405060708090a0b0c0d0e0f101112")
+    hex_multiline
     ( "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f\n"
     ^ "10 11 12")
 
@@ -166,6 +169,14 @@ let hexdump_aligned_to_half () =
   test_hexdump
     (Cstruct.of_hex "0001020304050607")
     "00 01 02 03 04 05 06 07"
+
+let hexdump_in_box () =
+  test_hexdump
+    ~format:"This is a box : %a"
+    hex_multiline
+    ( "This is a box : 00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f\n"
+    ^ "                10 11 12"
+    )
 
 let suite = [
   "fillv", [
@@ -195,6 +206,7 @@ let suite = [
     "multiline", `Quick, hexdump_multiline;
     "aligned", `Quick, hexdump_aligned;
     "aligned to half", `Quick, hexdump_aligned_to_half;
+    "in box", `Quick, hexdump_in_box;
   ]
 ]
 

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -149,23 +149,23 @@ let hexdump_empty () =
 let hexdump_small () =
   test_hexdump
     (Cstruct.of_hex "00010203")
-    "00 01 02 03 "
+    "00 01 02 03"
 
 let hexdump_multiline () =
   test_hexdump
     (Cstruct.of_hex "000102030405060708090a0b0c0d0e0f101112")
-    ( "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f \n"
-    ^ "10 11 12 ")
+    ( "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f\n"
+    ^ "10 11 12")
 
 let hexdump_aligned () =
   test_hexdump
     (Cstruct.of_hex "000102030405060708090a0b0c0d0e0f")
-    "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f \n"
+    "00 01 02 03 04 05 06 07  08 09 0a 0b 0c 0d 0e 0f\n"
 
 let hexdump_aligned_to_half () =
   test_hexdump
     (Cstruct.of_hex "0001020304050607")
-    "00 01 02 03 04 05 06 07  "
+    "00 01 02 03 04 05 06 07"
 
 let suite = [
   "fillv", [


### PR DESCRIPTION
Hello,

I added some tests for `hexdump_pp`.

The formatting seems a bit off to me:
- there are trailing spaces
- there is no newline at the end

I believe that the trailing spaces should be removed, but I'm not too sure about the trailing newlines.

Let me know what you think.