### PR TITLE
Add Cstruct.rev to build a reversed cstruct

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -482,6 +482,16 @@ let concat = function
       ignore @@ List.fold_left aux 0 css ;
       result
 
+let rev t =
+  let n = len t in
+  let out = create_unsafe n in
+  for i_src = 0 to n - 1 do
+    let byte = get_uint8 t i_src in
+    let i_dst = n - 1 - i_src in
+    set_uint8 out i_dst byte
+  done;
+  out
+
 open Sexplib
 
 let buffer_of_sexp b = Conv.bigstring_of_sexp b

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -501,3 +501,6 @@ val append: t -> t -> t
 val concat: t list -> t
 (** [concat ts] is the concatenation of all the [ts]. It is not guaranteed that
  * the result is a newly created [t] in the zero- and one-element cases. *)
+
+val rev: t -> t
+(** [rev t] is [t] in reverse order. *)

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -503,4 +503,5 @@ val concat: t list -> t
  * the result is a newly created [t] in the zero- and one-element cases. *)
 
 val rev: t -> t
-(** [rev t] is [t] in reverse order. *)
+(** [rev t] is [t] in reverse order. The return value is a freshly allocated
+    cstruct, and the argument is not modified. *)

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -137,6 +137,18 @@ let check_alignment_large () =
     try let _ = check () in Alcotest.fail "alignement should raise"
     with Invalid_argument _ -> ()
 
+let rev_empty () =
+  assert_cs_equal Cstruct.empty (Cstruct.rev Cstruct.empty)
+
+let rev_len_1 () =
+  let cs = Cstruct.of_string "a" in
+  assert_cs_equal cs (Cstruct.rev cs)
+
+let rev_len_5 () =
+  let cs = Cstruct.of_string "abcde" in
+  let expected = Cstruct.of_string "edcba" in
+  assert_cs_equal expected (Cstruct.rev cs)
+
 let suite = [
   "fillv", [
     "fillv", `Quick, fillv
@@ -158,6 +170,11 @@ let suite = [
     "aligned to 512"  , `Quick, check_alignment 512;
     "aligned to 0"    , `Quick, check_alignment_zero;
     "aligned to large", `Quick, check_alignment_large;
+  ];
+  "rev", [
+    "empty", `Quick, rev_empty;
+    "len = 1", `Quick, rev_len_1;
+    "len = 5", `Quick, rev_len_5;
   ]
 ]
 


### PR DESCRIPTION
It's like `List.rev`, but for cstructs. Let me know what you think.