### PR TITLE
prepare 3.5.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+v3.5.0 2019-02-26
+-----------------
+
+- Remove trailing spaces in hexdump output (#219 @emillon)
+- Add `Cstruct.rev` to allocate a reversed cstruct (#221 @emillon)
+- `Cstruct_unix` now uses the post-OCaml 4.06 `Unix.map_file`
+  instead of the deprecated Bigarray `map_file` that was removed
+  in OCaml 4.08 (@avsm, see ocaml/ocaml#2263)
+- Remove unnecessary `(wrapped false)` in the build system (@avsm)
+- Correct ocamldoc to the right `cstruct-ppx` package pointer (@avsm)
+
 v3.4.0 2019-02-02
 -----------------
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ clean:
 test:
 	dune runtest
 
+doc:
+	dune build @doc
+
 build-fuzz:
 	dune build fuzz/fuzz.exe
 

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -15,7 +15,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.06.0"}
   "dune" {build & >= "1.0"}
   "base-unix"
   "cstruct" {>="3.2.0"}

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -21,7 +21,7 @@ structures directly from OCaml.  It supports both reading and writing to these
 memory buffers, and they are accessed via the [Bigarray] module.
 
 The library interface below is intended to be used in conjunction with the
-ppx rewriter that is also supplied with this library (in the [cstruct.ppx]
+ppx rewriter that is also supplied with this library (in the [cstruct-ppx]
 ocamlfind package).
 
 An example description for the pcap packet format is:

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,5 @@
 (library
  (name cstruct)
  (public_name cstruct)
- (modules cstruct)
- (wrapped false)
  (libraries sexplib)
  (c_names cstruct_stubs))

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -216,6 +216,7 @@ let suite = [
     "empty", `Quick, rev_empty;
     "len = 1", `Quick, rev_len_1;
     "len = 5", `Quick, rev_len_5;
+  ];
   "hexdump", [
     "empty", `Quick, hexdump_empty;
     "small", `Quick, hexdump_small;

--- a/unix/dune
+++ b/unix/dune
@@ -2,5 +2,4 @@
  (name cstruct_unix)
  (wrapped false)
  (public_name cstruct-unix)
- (flags :standard -w -3)
  (libraries cstruct unix))

--- a/unix/unix_cstruct.ml
+++ b/unix/unix_cstruct.ml
@@ -15,5 +15,5 @@
  *)
 
 let of_fd fd =
-  let buffer = Bigarray.(Array1.map_file fd char c_layout false (-1)) in
+  let buffer = Bigarray.(array1_of_genarray (Unix.map_file fd char c_layout false [|-1|])) in
   Cstruct.of_bigarray buffer


### PR DESCRIPTION
this changeset includes:

- `Cstruct_unix` now uses the post-OCaml 4.06 `Unix.map_file` instead of the deprecated Bigarray `map_file` that was removed in OCaml 4.08 (@avsm, see ocaml/ocaml#2263)
- Remove unnecessary `(wrapped false)` in the build system (@avsm)
- Correct ocamldoc to the right `cstruct-ppx` package pointer (@avsm)


