### PR TITLE
Suppress warning 32

### DIFF
--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -145,7 +145,7 @@ let output_get _loc s f =
         let [%p Ast.pvar (op_name "get" s f)] =
           fun src -> Cstruct.sub src [%e num f.off] [%e num len]];
       [%stri
-        let [%p Ast.pvar (op_name "copy" s f)] =
+        let[@ocaml.warning "-32"] [%p Ast.pvar (op_name "copy" s f)] =
           fun src -> Cstruct.copy src [%e num f.off] [%e num len]]
     ]
   |Prim prim ->
@@ -197,16 +197,16 @@ let output_set _loc s f =
     let len = width_of_field f in
     [
       [%stri
-        let [%p Ast.pvar (setter_name s f)] = fun src srcoff dst ->
+        let[@ocaml.warning "-32"] [%p Ast.pvar (setter_name s f)] = fun src srcoff dst ->
           Cstruct.blit_from_string src srcoff dst [%e num f.off] [%e num len]];
       [%stri
-        let [%p Ast.pvar (op_name "blit" s f)] = fun src srcoff dst ->
+        let[@ocaml.warning "-32"] [%p Ast.pvar (op_name "blit" s f)] = fun src srcoff dst ->
           Cstruct.blit src srcoff dst [%e num f.off] [%e num len]]
     ]
   |Prim prim ->
     [
       [%stri
-        let [%p Ast.pvar (setter_name s f)] = fun v x ->
+        let[@ocaml.warning "-32"] [%p Ast.pvar (setter_name s f)] = fun v x ->
           [%e match prim with
               |Char -> [%expr Cstruct.set_char v [%e num f.off] x]
               |UInt8 -> [%expr Cstruct.set_uint8 v [%e num f.off] x]
@@ -266,7 +266,7 @@ let output_hexdump _loc s =
       let [%p Ast.pvar ("hexdump_"^s.name^"_to_buffer")] = fun _buf v ->
         [%e hexdump]];
     [%stri
-      let [%p Ast.pvar ("hexdump_"^s.name)] = fun v ->
+      let[@ocaml.warning "-32"] [%p Ast.pvar ("hexdump_"^s.name)] = fun v ->
         let _buf = Buffer.create 128 in
         Buffer.add_string _buf [%e Ast.str (s.name ^ " = {\n")];
         [%e Ast.evar ("hexdump_"^s.name^"_to_buffer")] _buf v;

--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -83,10 +83,6 @@ let field_to_string f =
   in
   sprintf "%s %s" (string f.ty) f.field
 
-let to_string t =
-  sprintf "cstruct[%d] %s { %s }" t.len t.name
-    (String.concat "; " (List.map field_to_string t.fields))
-
 let loc_err loc fmt = Location.raise_errorf ~loc ("ppx_cstruct error: " ^^ fmt)
 
 let parse_field loc field field_type sz =

--- a/ppx_test/basic.ml
+++ b/ppx_test/basic.ml
@@ -61,6 +61,17 @@ type bibar = {
 } [@@bi_endian]
 ]
 
+(** This should not emit any warnings *)
+[%%cstruct
+type unused = {
+  a : uint8_t;
+  b : uint16_t;
+  c : uint32_t;
+  d : uint8_t;
+  e : uint8_t; [@len 16]
+} [@@big_endian]
+]
+
 let tests () =
   (* Test basic set/get functions *)
   let be = Cstruct.of_bigarray (Bigarray.(Array1.create char c_layout sizeof_foo)) in

--- a/ppx_test/pcap.ml
+++ b/ppx_test/pcap.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-[@@@ocaml.warning "-32"]
-
 [%%cstruct
 type pcap_header = {
   magic_number: uint32_t;   (* magic number *)
@@ -67,8 +65,6 @@ type tcpv4 = {
   checksum: uint16_t;
   urg: uint16_t;
 } [@@big_endian]]
-
-[@@@ocaml.warning "+32"]
 
 let mac_to_string buf =
   let i n = Cstruct.get_uint8 buf n in


### PR DESCRIPTION
(see #225)

A `[%%cstruct type ...]` declaration creates many declarations, potentially unused. It is common in many ppxs to generate warning-free code. In particular, many projects that use `ppx_cstruct` seem to locally suppress these warnings.

The function names were computed in several places, so took the opportunity to extract an intermediate `op` type and compute these names in a single place. Let me know if that works for you, otherwise it's easy to remove.

Thanks!