### PR TITLE
Sexplib is now an optional library for the base `Cstruct` module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex ./.travis-docker.sh
 env:
   global:
-  - PINS="cstruct:. cstruct-async:. cstruct-lwt:. cstruct-unix:. ppx_cstruct:."
+  - PINS="cstruct:. cstruct-sexp:. cstruct-async:. cstruct-lwt:. cstruct-unix:. ppx_cstruct:."
   matrix:
   - PACKAGE="cstruct"       DISTRO="alpine"   OCAML_VERSION="4.03"
   - PACKAGE="cstruct"       DISTRO="alpine"   OCAML_VERSION="4.04"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+v4.0.0
+------
+
+- Sexplib is now an optional library for the base `Cstruct` module.
+  A new `Cstruct_sexp` module has been introduced with the serialiser
+  functions, contained within the `cstruct-sexp` opam package.
+
+  To convert old code, simply use `Cstruct_sexp.t` instead of
+  `Cstruct.t` in a record type for which you are using `[@@deriving sexp]`.
+  This is a type alias to `Cstruct.t` but also has the right
+  sexp-conversion functions in scope.  There is an example of this
+  in the `ppx_test/with-sexp` directory in the source repo.
+
+  When you have converted and released your library, add an
+  opam constraint of `cstruct {>="4.0.0"}` to your own opam
+  packages to ensure that they pick up this version of the library.
+  (fixes #222, @avsm)
+
+- Use computed versions in opam files to ensure that dependent
+  opam packages such as cstruct-async get the same base version
+  of cstruct to avoid mismatches.
+
 v3.7.0 2019-03-10
 -----------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+v3.7.0 2019-03-10
+-----------------
+
+- Improve performance by not doing redundant bounds checks
+  in both the Bigarray and Cstruct level (#236 @Reperator @chambart)
+- Ignore fields starting wih `_` by skipping code generation
+  but still respecting the space usage of that field. This was
+  a convention before but is now enforced by the code generator
+  to save space in the output (#233 @emillon)
+- More warnings suppression for sizeof and enums (#231 @emillon)
+
 v3.6.0 2019-03-01
 -----------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,10 @@ v4.0.0
 
 - Use computed versions in opam files to ensure that dependent
   opam packages such as cstruct-async get the same base version
-  of cstruct to avoid mismatches.
+  of cstruct to avoid mismatches. (@avsm)
+
+- Add a ppx test suite to checks that all error paths in ppx
+  handling are reachable and have meaningful location info (#238 @emillon)
 
 v3.7.0 2019-03-10
 -----------------

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -19,7 +19,7 @@ depends: [
   "async_kernel" {>= "v0.9.0" & < "v0.12"}
   "async_unix" {>= "v0.9.0" & < "v0.12"}
   "core_kernel" {>= "v0.9.0" & < "v0.12"}
-  "cstruct" {>= "3.2.0"}
+  "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -2,29 +2,30 @@ opam-version: "2.0"
 maintainer:   "anil@recoil.org"
 authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
                "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
-               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
 homepage:     "https://github.com/mirage/ocaml-cstruct"
 license:      "ISC"
 dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
 bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
 doc: "https://mirage.github.io/ocaml-cstruct/"
+
 tags: [ "org:mirage" "org:ocamllabs" ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "base-unix"
-  "lwt"
-  "cstruct" {=version}
   "dune" {build & >= "1.0"}
+  "sexplib" {< "v0.12"}
+  "cstruct" {=version}
+  "alcotest" {with-test}
 ]
-synopsis: "Access C-like structures directly from OCaml"
+synopsis: "Sexp serialisers for C-like structures"
 description: """
 Cstruct is a library and syntax extension to make it easier to access C-like
 structures directly from OCaml.  It supports both reading and writing to these
-structures, and they are accessed via the `Bigarray` module."""
-url {
-  src: "git+https://github.com/mirage/ocaml-cstruct.git"
-}
+structures, and they are accessed via the `Bigarray` module.
+
+This library provides Sexplib serialisers for the Cstruct.t values."""

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -22,7 +22,7 @@ depends: [
   "cstruct" {>= "3.6.0"}
   "alcotest" {with-test}
 ]
-synopsis: "Sexp serialisers for C-like structures"
+synopsis: "S-expression serialisers for C-like structures"
 description: """
 Cstruct is a library and syntax extension to make it easier to access C-like
 structures directly from OCaml.  It supports both reading and writing to these

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {build & >= "1.0"}
   "base-unix"
-  "cstruct" {>="3.2.0"}
+  "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 

--- a/cstruct.opam
+++ b/cstruct.opam
@@ -18,7 +18,6 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
-  "sexplib" {< "v0.12"}
   "alcotest" {with-test}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -500,23 +500,3 @@ let rev t =
     set_uint8 out i_dst byte
   done;
   out
-
-open Sexplib
-
-let buffer_of_sexp b = Conv.bigstring_of_sexp b
-let sexp_of_buffer b = Conv.sexp_of_bigstring b
-
-let t_of_sexp = function
-  | Sexp.Atom str ->
-      let n = String.length str in
-      let t = create_unsafe n in
-      blit_from_string str 0 t 0 n ;
-      t
-  | sexp -> Conv.of_sexp_error "Cstruct.t_of_sexp: atom needed" sexp
-
-let sexp_of_t t =
-  let n   = len t in
-  let str = Bytes.create n in
-  blit_to_bytes t 0 str 0 n ;
-  (* The following call is safe, since str is not visible elsewhere. *)
-  Sexp.Atom (Bytes.unsafe_to_string str)

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -140,26 +140,12 @@ type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Arr
 (** Type of a buffer. A cstruct is composed of an underlying buffer
     and position/length within this buffer. *)
 
-val sexp_of_buffer : buffer -> Sexplib.Sexp.t
-(** [sexp_of_buffer b] returns the s-expression representation of the raw memory buffer [b] *)
-
-val buffer_of_sexp : Sexplib.Sexp.t -> buffer
-(** [buffer_of_sexp s] returns a fresh memory buffer from the s-expression [s].
-    [s] should have been constructed using {!sexp_of_buffer}. *)
-
 type t = private {
   buffer: buffer;
   off   : int;
   len   : int;
 }
 (** Type of a cstruct. *)
-
-val sexp_of_t : t -> Sexplib.Sexp.t
-(** [sexp_of_t t] returns the s-expression representation of the Cstruct [t] *)
-
-val t_of_sexp : Sexplib.Sexp.t -> t
-(** [t_of_sexp s] returns a fresh {!Cstruct.t} that represents the
-     s-expression previously serialised by {!sexp_of_t}. *)
 
 type byte = char
 (** A single byte type *)

--- a/lib/cstruct_sexp.ml
+++ b/lib/cstruct_sexp.ml
@@ -1,0 +1,38 @@
+(*
+ * Copyright (c) 2012-2019 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+open Sexplib
+
+type buffer = Cstruct.buffer
+type t = Cstruct.t
+
+let buffer_of_sexp b = Conv.bigstring_of_sexp b
+let sexp_of_buffer b = Conv.sexp_of_bigstring b
+
+let t_of_sexp = function
+  | Sexp.Atom str ->
+      let n = String.length str in
+      let t = Cstruct.create_unsafe n in
+      Cstruct.blit_from_string str 0 t 0 n ;
+      t
+  | sexp -> Conv.of_sexp_error "Cstruct.t_of_sexp: atom needed" sexp
+
+let sexp_of_t t =
+  let n   = Cstruct.len t in
+  let str = Bytes.create n in
+  Cstruct.blit_to_bytes t 0 str 0 n ;
+  (* The following call is safe, since str is not visible elsewhere. *)
+  Sexp.Atom (Bytes.unsafe_to_string str)

--- a/lib/cstruct_sexp.mli
+++ b/lib/cstruct_sexp.mli
@@ -1,0 +1,38 @@
+(*
+ * Copyright (c) 2012-2019 Anil Madhavapeddy <anil@recoil.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+
+(** Sexpression serialisers for {!Cstruct.t} values *)
+
+type buffer = Cstruct.buffer
+(** [buffer] is an alias for the corresponding {!Cstruct.buffer} type *)
+
+val sexp_of_buffer : Cstruct.buffer -> Sexplib.Sexp.t
+(** [sexp_of_buffer b] returns the s-expression representation of the raw memory buffer [b] *)
+
+val buffer_of_sexp : Sexplib.Sexp.t -> Cstruct.buffer
+(** [buffer_of_sexp s] returns a fresh memory buffer from the s-expression [s].
+    [s] should have been constructed using {!sexp_of_buffer}. *)
+
+type t = Cstruct.t
+(** [t] is an alias for the corresponding {!Cstruct.t} type *)
+
+val sexp_of_t : t -> Sexplib.Sexp.t
+(** [sexp_of_t t] returns the s-expression representation of the Cstruct [t] *)
+
+val t_of_sexp : Sexplib.Sexp.t -> t
+(** [t_of_sexp s] returns a fresh {!Cstruct.t} that represents the
+     s-expression previously serialised by {!sexp_of_t}. *)
+

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,12 @@
 (library
  (name cstruct)
  (public_name cstruct)
- (libraries sexplib)
- (c_names cstruct_stubs))
+ (libraries bigarray)
+ (c_names cstruct_stubs)
+ (modules cstruct))
+
+(library
+ (name cstruct_sexp)
+ (public_name cstruct-sexp)
+ (modules cstruct_sexp)
+ (libraries cstruct sexplib))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,9 +1,9 @@
 (executable
- (libraries cstruct alcotest)
+ (libraries cstruct alcotest cstruct-sexp)
  (name tests))
 
 (alias
  (name runtest)
- (package cstruct)
+ (package cstruct-sexp)
  (action
   (run ./tests.exe -e)))

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -6,10 +6,10 @@ let random_cs ?(len = Random.int 128) () =
   cs
 
 let to_string_as_sexp cs =
-  Sexplib.Sexp.to_string_mach (Cstruct.sexp_of_t cs)
+  Sexplib.Sexp.to_string_mach (Cstruct_sexp.sexp_of_t cs)
 
 let of_string_as_sexp str =
-  Cstruct.t_of_sexp (Sexplib.Sexp.of_string str)
+  Cstruct_sexp.t_of_sexp (Sexplib.Sexp.of_string str)
 
 let assert_cs_equal ?(msg="cstruct") cs1 cs2 =
   let cstruct =

--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
-  "cstruct" {>= "3.1.1"}
+  "cstruct" {=version}
   "ounit" {with-test}
   "ppx_tools_versioned" {>= "5.0.1"}
   "ocaml-migrate-parsetree"

--- a/ppx_test/basic.ml
+++ b/ppx_test/basic.ml
@@ -175,7 +175,7 @@ let tests () =
   assert(get_foo_b be = 44);
   assert(get_foo_a be = 7);
   hexdump_foo be;
-  print_endline (Sexplib.Sexp.to_string_hum (Cstruct.sexp_of_t be));
+  print_endline (Sexplib.Sexp.to_string_hum (Cstruct_sexp.sexp_of_t be));
   hexdump_with_ignored_field (Cstruct.of_hex "010203")
 
 let () = tests ()

--- a/ppx_test/dune
+++ b/ppx_test/dune
@@ -1,6 +1,6 @@
 (tests
  (names pcap basic enum)
  (deps http.cap)
- (libraries cstruct-unix)
+ (libraries cstruct-unix sexplib cstruct-sexp)
  (preprocess (pps ppx_cstruct))
  (package ppx_cstruct))

--- a/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
+++ b/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
@@ -2,5 +2,13 @@
   magic: uint8_t [@len 16];
 }[@@little_endian]]
 
+[%%cenum
+type foo64 =
+  | ONE64
+  | TWO64
+  | THREE64
+  [@@uint64_t]
+]
+
 let%lwt foo = Lwt.return ()
 

--- a/ppx_test/with-sexp/dune
+++ b/ppx_test/with-sexp/dune
@@ -1,8 +1,7 @@
 (executable
  (name ppx_cstruct_and_sexp)
- (preprocess
-  (pps ppx_cstruct ppx_sexp_conv -- -no-check))
- (libraries cstruct))
+ (preprocess (pps ppx_cstruct ppx_sexp_conv -- -no-check))
+ (libraries cstruct sexplib cstruct-sexp))
 
 (alias
  (name runtest)

--- a/ppx_test/with-sexp/ppx_cstruct_and_sexp.ml
+++ b/ppx_test/with-sexp/ppx_cstruct_and_sexp.ml
@@ -4,3 +4,8 @@
 
 open Sexplib.Std
 type t = int [@@deriving sexp]
+
+type bar = {
+  buf: Cstruct_sexp.t;
+  string: string;
+} [@@deriving sexp]


### PR DESCRIPTION
A new `Cstruct_sexp` module has been introduced with the serialiser functions, contained within the `cstruct-sexp` opam package.

To convert old code, simply use `Cstruct_sexp.t` instead of `Cstruct.t` in a record type for which you are using `[@@deriving sexp]`. This is a type alias to `Cstruct.t` but also has the right sexp-conversion functions in scope.  There is an example of this in the `ppx_test/with-sexp` directory in the source repo.

fixes #222, cc @TheLortex