### PR TITLE
Detect duplicate fields in %%cstruct types

### DIFF
--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -100,7 +100,7 @@ let field_to_string f =
   in
   sprintf "%s %s" (string f.ty) f.name
 
-let loc_err loc fmt = Location.raise_errorf ~loc ("ppx_cstruct error: " ^^ fmt)
+let loc_err loc fmt = Location.raise_errorf ~loc ("ppx_cstruct: " ^^ fmt)
 
 let parse_field loc name field_type sz =
   match ty_of_string field_type with

--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -105,7 +105,7 @@ let check_for_duplicates loc fields =
   let _ : StringSet.t =
     List.fold_left (fun seen f ->
         let name = f.field in
-        if StringSet.mem name seen then
+        if not (field_is_ignored f) && StringSet.mem name seen then
           loc_err loc "field %s is present several times in this type" name
         else
           StringSet.add name seen

--- a/ppx_test/basic.ml
+++ b/ppx_test/basic.ml
@@ -96,6 +96,16 @@ type unused_cenum =
   [@@int16_t] [@@sexp]
 ]
 
+(** Duplicate _ fields are OK *)
+[%%cstruct
+type with_several_ignored =
+{ x : int8_t
+; _y : int8_t
+; z : int8_t
+; _y : int8_t
+} [@@little_endian]
+]
+
 let tests () =
   (* Test basic set/get functions *)
   let be = Cstruct.of_bigarray (Bigarray.(Array1.create char c_layout sizeof_foo)) in

--- a/ppx_test/errors/cenum_id_payload.ml.expected
+++ b/ppx_test/errors/cenum_id_payload.ml.expected
@@ -1,2 +1,2 @@
 File "cenum_id_payload.ml", line 2, characters 18-20:
-Error: ppx_cstruct error: invalid id
+Error: ppx_cstruct: invalid id

--- a/ppx_test/errors/cenum_invalid_type.ml.expected
+++ b/ppx_test/errors/cenum_invalid_type.ml.expected
@@ -1,2 +1,2 @@
 File "cenum_invalid_type.ml", line 2, characters 11-19:
-Error: ppx_cstruct error: invalid cenum variant
+Error: ppx_cstruct: invalid cenum variant

--- a/ppx_test/errors/cenum_no_attribute.ml.expected
+++ b/ppx_test/errors/cenum_no_attribute.ml.expected
@@ -1,2 +1,2 @@
 File "cenum_no_attribute.ml", line 2, characters 2-18:
-Error: ppx_cstruct error: invalid cenum attributes
+Error: ppx_cstruct: invalid cenum attributes

--- a/ppx_test/errors/cenum_not_a_variant.ml.expected
+++ b/ppx_test/errors/cenum_not_a_variant.ml.expected
@@ -1,2 +1,2 @@
 File "cenum_not_a_variant.ml", line 2, characters 2-34:
-Error: ppx_cstruct error: expected variant type
+Error: ppx_cstruct: expected variant type

--- a/ppx_test/errors/cenum_unknown_attribute.ml.expected
+++ b/ppx_test/errors/cenum_unknown_attribute.ml.expected
@@ -1,2 +1,2 @@
 File "cenum_unknown_attribute.ml", line 2, characters 2-32:
-Error: ppx_cstruct error: enum: unknown width specifier uint9_t
+Error: ppx_cstruct: enum: unknown width specifier uint9_t

--- a/ppx_test/errors/cstruct_attribute_payload.ml.expected
+++ b/ppx_test/errors/cstruct_attribute_payload.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_attribute_payload.ml", line 2, characters 2-57:
-Error: ppx_cstruct error: no attribute payload expected
+Error: ppx_cstruct: no attribute payload expected

--- a/ppx_test/errors/cstruct_duplicate_field.ml
+++ b/ppx_test/errors/cstruct_duplicate_field.ml
@@ -1,0 +1,7 @@
+[%%cstruct
+type dup = {
+  x : uint8_t;
+  y : uint8_t;
+  x : uint8_t;
+} [@@little_endian]
+]

--- a/ppx_test/errors/cstruct_duplicate_field.ml.expected
+++ b/ppx_test/errors/cstruct_duplicate_field.ml.expected
@@ -1,2 +1,2 @@
-File "cstruct_duplicate_field.ml", line 2, characters 0-77:
+File "cstruct_duplicate_field.ml", line 5, characters 2-14:
 Error: ppx_cstruct error: field x is present several times in this type

--- a/ppx_test/errors/cstruct_duplicate_field.ml.expected
+++ b/ppx_test/errors/cstruct_duplicate_field.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_duplicate_field.ml", line 5, characters 2-14:
-Error: ppx_cstruct error: field x is present several times in this type
+Error: ppx_cstruct: field x is present several times in this type

--- a/ppx_test/errors/cstruct_duplicate_field.ml.expected
+++ b/ppx_test/errors/cstruct_duplicate_field.ml.expected
@@ -1,0 +1,2 @@
+File "cstruct_duplicate_field.ml", line 2, characters 0-77:
+Error: ppx_cstruct error: field x is present several times in this type

--- a/ppx_test/errors/cstruct_multiple_len.ml.expected
+++ b/ppx_test/errors/cstruct_multiple_len.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_multiple_len.ml", line 3, characters 4-35:
-Error: ppx_cstruct error: multiple field length attribute
+Error: ppx_cstruct: multiple field length attribute

--- a/ppx_test/errors/cstruct_not_a_record.ml.expected
+++ b/ppx_test/errors/cstruct_not_a_record.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_not_a_record.ml", line 2, characters 2-14:
-Error: ppx_cstruct error: record type declaration expected
+Error: ppx_cstruct: record type declaration expected

--- a/ppx_test/errors/cstruct_not_an_identifier.ml.expected
+++ b/ppx_test/errors/cstruct_not_an_identifier.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_not_an_identifier.ml", line 3, characters 8-20:
-Error: ppx_cstruct error: type identifier expected
+Error: ppx_cstruct: type identifier expected

--- a/ppx_test/errors/cstruct_several_attributes.ml.expected
+++ b/ppx_test/errors/cstruct_several_attributes.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_several_attributes.ml", line 2, characters 2-71:
-Error: ppx_cstruct error: too many attributes
+Error: ppx_cstruct: too many attributes

--- a/ppx_test/errors/cstruct_unknown_endian.ml.expected
+++ b/ppx_test/errors/cstruct_unknown_endian.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_unknown_endian.ml", line 2, characters 2-49:
-Error: ppx_cstruct error: unknown endian unknown_endian, should be little_endian, big_endian, host_endian or bi_endian
+Error: ppx_cstruct: unknown endian unknown_endian, should be little_endian, big_endian, host_endian or bi_endian

--- a/ppx_test/errors/cstruct_unknown_type.ml.expected
+++ b/ppx_test/errors/cstruct_unknown_type.ml.expected
@@ -1,2 +1,2 @@
 File "cstruct_unknown_type.ml", line 3, characters 4-15:
-Error: ppx_cstruct error: Unknown type uint9_t
+Error: ppx_cstruct: Unknown type uint9_t

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -84,6 +84,20 @@
     (diff cstruct_attribute_payload.ml.expected cstruct_attribute_payload.ml.errors)))
 
 (rule
+  (deps pp.exe (:input cstruct_duplicate_field.ml))
+  (targets cstruct_duplicate_field.ml.errors)
+  (action
+    (with-stderr-to
+      %{targets}
+      (system "./pp.exe --impl %{input} || true"))))
+
+(alias
+  (name runtest)
+  (package ppx_cstruct)
+  (action
+    (diff cstruct_duplicate_field.ml.expected cstruct_duplicate_field.ml.errors)))
+
+(rule
   (deps pp.exe (:input cstruct_multiple_len.ml))
   (targets cstruct_multiple_len.ml.errors)
   (action


### PR DESCRIPTION
See #235

This can happen when copy/pasting, so it is helpful to detect that.

This includes a refactor so that ignored fields are first class, and also improves the error messages.