### PR TITLE
Support 0.12 version of sexplib - fix #242

### DIFF
--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.12"}
-  "async_unix" {>= "v0.9.0" & < "v0.12"}
-  "core_kernel" {>= "v0.9.0" & < "v0.12"}
+  "async_kernel" {>= "v0.9.0" & < "v0.13"}
+  "async_unix" {>= "v0.9.0" & < "v0.13"}
+  "core_kernel" {>= "v0.9.0" & < "v0.13"}
   "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
-  "sexplib" {< "v0.12"}
+  "sexplib" {< "v0.13"}
   "cstruct" {>= "3.6.0"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
I noticed there is no anything specific used, blocking the use of 0.12 version.