### PR TITLE
Update fuzz tests to released crowbar API

### DIFF
--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,3 +1,3 @@
 (executable
  (name fuzz)
- (libraries cstruct crowbar fmt))
+ (libraries cstruct cstruct-sexp crowbar fmt))

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -11,31 +11,33 @@ let create_sub x start len =
     Cstruct.sub c start len
   with Invalid_argument _ -> bad_test ()
 
-let cstruct = Choose [
-    Map ([int8], create);
-    Map ([range 0x10000; int; int], create_sub);
+let cstruct = choose [
+    map [int8] create;
+    map [range 0x10000; int; int] create_sub;
   ]
 
-let buffer = Map ([uint8], Bigarray.(Array1.create Char c_layout))
+let bytes = map [bytes] Bytes.unsafe_of_string
+
+let buffer = map [uint8] Bigarray.(Array1.create Char c_layout)
 
 let pp_cstruct f c = Format.pp_print_string f (Cstruct.debug c)
 
 let () =
   assert (Array.length Sys.argv = 2);   (* Prevent accidentally running in quickcheck mode *)
   add_test ~name:"blit" [cstruct; int; cstruct; int; int] (fun src srcoff dst dstoff len ->
-      try Cstruct.blit src srcoff dst dstoff len; Ok ()
-      with Invalid_argument _ -> Ok ()
+      try Cstruct.blit src srcoff dst dstoff len
+      with Invalid_argument _ -> ()
     );
   add_test ~name:"sexp" [buffer] (fun b ->
-      b |> Cstruct.sexp_of_buffer |> Cstruct.buffer_of_sexp
+      b |> Cstruct_sexp.sexp_of_buffer |> Cstruct_sexp.buffer_of_sexp
       |> check_eq
         ~cmp:(fun x y -> Cstruct.compare (Cstruct.of_bigarray x) (Cstruct.of_bigarray y))
         b
     );
-  add_test ~name:"of_bigarray" [buffer; Option int; Option int] (fun b off len ->
+  add_test ~name:"of_bigarray" [buffer; option int; option int] (fun b off len ->
       match Cstruct.of_bigarray b ?off ?len with
       | c -> check (Cstruct.len c <= Bigarray.Array1.dim b)
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"get_char" [cstruct; int] (fun c off ->
       let in_range = off >= 0 && off < Cstruct.len c in
@@ -53,45 +55,45 @@ let () =
       Fmt.pr "sub %d %d\n%!" off len;
       match Cstruct.sub c off len with
       | sub -> check (Cstruct.len sub <= Cstruct.len c);
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"shift" [cstruct; int] (fun c off ->
       match Cstruct.shift c off with
       | sub -> check (Cstruct.len sub <= Cstruct.len c);
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"copy" [cstruct; int; int] (fun c off len ->
       match Cstruct.copy c off len with
       | sub -> check (String.length sub <= Cstruct.len c);
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"blit_from_bytes" [bytes; int; cstruct; int; int] (fun src srcoff dst dstoff len ->
       match Cstruct.blit_from_bytes src srcoff dst dstoff len with
-      | () -> Ok ()
-      | exception Invalid_argument _ -> Ok ()
+      | () -> ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"blit_to_bytes" [cstruct; int; bytes; int; int] (fun src srcoff dst dstoff len ->
       match Cstruct.blit_to_bytes src srcoff dst dstoff len with
-      | () -> Ok ()
-      | exception Invalid_argument _ -> Ok ()
+      | () -> ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"memset" [cstruct; int] (fun c x ->
-      Cstruct.memset c x; Ok ()
+      Cstruct.memset c x
     );
   add_test ~name:"set_len" [cstruct; int] (fun c x ->
       match Cstruct.set_len c x with
       | c2 -> check (Cstruct.len c2 <= Cstruct.len c)
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"add_len" [cstruct; int] (fun c x ->
       match Cstruct.add_len c x with
       | c2 -> check (Cstruct.len c2 <= Cstruct.len c)
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
-  add_test ~name:"split" [cstruct; Option int; int] (fun c start len ->
+  add_test ~name:"split" [cstruct; option int; int] (fun c start len ->
       match Cstruct.split ?start c len  with
       | c1, c2 -> check (Cstruct.len c2 <= Cstruct.len c && Cstruct.len c1 <= Cstruct.len c)
-      | exception Invalid_argument _ -> Ok ()
+      | exception Invalid_argument _ -> ()
     );
   add_test ~name:"BE.set_uint64" [cstruct; int] (fun c off ->
       let in_range = off >= 0 && off < Cstruct.len c - 7 in
@@ -99,17 +101,17 @@ let () =
       | () -> check in_range
       | exception Invalid_argument _ -> check (not in_range)
     );
-  add_test ~name:"lenv" [List cstruct] (fun cs ->
+  add_test ~name:"lenv" [list cstruct] (fun cs ->
       check (Cstruct.lenv cs >= 0)
     );
-  add_test ~name:"copyv" [List cstruct] (fun cs ->
-      ignore (Cstruct.copyv cs); Ok ()
+  add_test ~name:"copyv" [list cstruct] (fun cs ->
+      ignore (Cstruct.copyv cs)
     );
-  add_test ~name:"fillv" [List cstruct; cstruct] (fun src dst ->
+  add_test ~name:"fillv" [list cstruct; cstruct] (fun src dst ->
       let copied, rest = Cstruct.fillv ~src ~dst in
       check (copied + Cstruct.lenv rest = Cstruct.lenv src);
     );
-  add_test ~name:"concat" [List cstruct] (fun cs ->
+  add_test ~name:"concat" [list cstruct] (fun cs ->
       let len = Cstruct.len (Cstruct.concat cs) in
       check (len >= 0 && len >= Cstruct.lenv cs);
     );


### PR DESCRIPTION
In https://github.com/mirage/ocaml-cstruct/pull/237#discussion_r268570118, @hannesm noted that some cstruct functions can be used to access memory outside of the original cstruct (but inside the original buffer), which seems a bit surprising. I noticed that the fuzz tests actually check for the safer behaviour, so I tried running them to see why they were passing. It turns out that they have bit-rotted and no longer compile.

This PR updates the tests to use the released crowbar API. I ran afl-fuzz on fuzz.exe, after a few minutes it reported three failures:

```
sub 0 204
sub: FAIL

When given the input:

    [#1 [44943; 0; 0]; 0; 204]
    
the test failed:

    check false
```

That is:

```ocaml
utop # let whole = Cstruct.create 44943 in
       let empty = Cstruct.sub whole 0 0 in
       Cstruct.sub empty 0 204;;
- : t = {buffer = <abstr>; off = 0; len = 204}
```

```
add_len: FAIL

When given the input:

    [#1 [60159; 8; 0]; 32768]
    
the test failed:

    check false
```

```
set_len: FAIL

When given the input:

    [#1 [61056; 0; 0]; 512]
    
the test failed:

    check false
```

I'm not sure what we expect the correct behaviour to be here, but either the tests or the code should be changed.