### PR TITLE
Fixes for #244

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -127,9 +127,9 @@ let debug t =
 
 let sub t off0 len =
   let off = t.off + off0 in
-  let offlen = off + len in
+  let new_end = off + len in
   let old_end = t.off + t.len in
-  if offlen > old_end || off < off0 || offlen < off || off0 < 0 || len < 0 || not (check_bounds t (offlen)) then err_sub t off0 len
+  if new_end > old_end || off < off0 || new_end < off || off0 < 0 || len < 0 || not (check_bounds t new_end) then err_sub t off0 len
   else { t with off; len }
 
 let shift t amount =

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -128,7 +128,8 @@ let debug t =
 let sub t off0 len =
   let off = t.off + off0 in
   let offlen = off + len in
-  if off < off0 || offlen < off || off0 < 0 || len < 0 || not (check_bounds t (offlen)) then err_sub t off0 len
+  let old_end = t.off + t.len in
+  if offlen > old_end || off < off0 || offlen < off || off0 < 0 || len < 0 || not (check_bounds t (offlen)) then err_sub t off0 len
   else { t with off; len }
 
 let shift t amount =

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -426,6 +426,15 @@ let test_subview_containment_set_char,
   test LE.set_uint32 0xffffffffl,
   test LE.set_uint64 0xffffffffffffffffL
 
+let regression_244 () =
+  let whole = Cstruct.create 44943 in
+  let empty = Cstruct.sub whole 0 0 in
+  try
+    let _big = Cstruct.sub empty 0 204 in
+    Alcotest.fail "could get a bigger buffer via sub"
+  with Invalid_argument _ -> ()
+
+
 let suite = [
   "test empty cstruct", `Quick, test_empty_cstruct;
   "test anti cstruct", `Quick, test_anti_cstruct;
@@ -479,4 +488,5 @@ let suite = [
   "test_subview_containment_set_le16", `Quick, test_subview_containment_set_le16;
   "test_subview_containment_set_le32", `Quick, test_subview_containment_set_le32;
   "test_subview_containment_set_le64", `Quick, test_subview_containment_set_le64;
+  "regression 244", `Quick, regression_244;
 ]


### PR DESCRIPTION
see #244 -- `sub` does one additional check, and `set_len/add_len` are marked as deprecated. //cc @talex5 