### PR TITLE
Use bigarray-compat

### DIFF
--- a/cstruct.opam
+++ b/cstruct.opam
@@ -18,6 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {build & >= "1.0"}
+  "bigarray-compat"
   "alcotest" {with-test}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,3 +1,3 @@
 (executable
  (name fuzz)
- (libraries cstruct cstruct-sexp crowbar fmt))
+ (libraries cstruct bigarray cstruct-sexp crowbar fmt))

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type buffer = (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
 
 (* Note:
  *
@@ -34,7 +34,7 @@ type t = {
 }
 
 let pp_t ppf t =
-  Format.fprintf ppf "[%d,%d](%d)" t.off t.len (Bigarray.Array1.dim t.buffer)
+  Format.fprintf ppf "[%d,%d](%d)" t.off t.len (Bigarray_compat.Array1.dim t.buffer)
 let string_t ppf str =
   Format.fprintf ppf "[%d]" (String.length str)
 let bytes_t ppf str =
@@ -80,7 +80,7 @@ let err_split t = err "Cstruct.split %a start=%d off=%d" pp_t t
 let err_iter t = err "Cstruct.iter %a i=%d len=%d" pp_t t
 
 let of_bigarray ?(off=0) ?len buffer =
-  let dim = Bigarray.Array1.dim buffer in
+  let dim = Bigarray_compat.Array1.dim buffer in
   let len =
     match len with
     | None     -> dim - off
@@ -89,14 +89,14 @@ let of_bigarray ?(off=0) ?len buffer =
   else { buffer; off; len }
 
 let to_bigarray buffer =
-  Bigarray.Array1.sub buffer.buffer buffer.off buffer.len
+  Bigarray_compat.Array1.sub buffer.buffer buffer.off buffer.len
 
 let create_unsafe len =
-  let buffer = Bigarray.(Array1.create char c_layout len) in
+  let buffer = Bigarray_compat.(Array1.create char c_layout len) in
   { buffer ; len ; off = 0 }
 
 let check_bounds t len =
-  len >= 0 && Bigarray.Array1.dim t.buffer >= len
+  len >= 0 && Bigarray_compat.Array1.dim t.buffer >= len
 
 let empty = create_unsafe 0
 
@@ -118,7 +118,7 @@ type uint32 = int32
 type uint64 = int64
 
 let debug t =
-  let max_len = Bigarray.Array1.dim t.buffer in
+  let max_len = Bigarray_compat.Array1.dim t.buffer in
   if t.off+t.len > max_len || t.len < 0 || t.off < 0 then (
     Format.printf "ERROR: t.off+t.len=%d %a\n%!" (t.off+t.len) pp_t t;
     assert false;
@@ -226,19 +226,19 @@ let create len =
 
 let set_uint8 t i c =
   if i >= t.len || i < 0 then err_invalid_bounds "set_uint8" t i 1
-  else Bigarray.Array1.set t.buffer (t.off+i) (Char.unsafe_chr c)
+  else Bigarray_compat.Array1.set t.buffer (t.off+i) (Char.unsafe_chr c)
 
 let set_char t i c =
   if i >= t.len || i < 0 then err_invalid_bounds "set_char" t i 1
-  else Bigarray.Array1.set t.buffer (t.off+i) c
+  else Bigarray_compat.Array1.set t.buffer (t.off+i) c
 
 let get_uint8 t i =
   if i >= t.len || i < 0 then err_invalid_bounds "get_uint8" t i 1
-  else Char.code (Bigarray.Array1.get t.buffer (t.off+i))
+  else Char.code (Bigarray_compat.Array1.get t.buffer (t.off+i))
 
 let get_char t i =
   if i >= t.len || i < 0 then err_invalid_bounds "get_char" t i 1
-  else Bigarray.Array1.get t.buffer (t.off+i)
+  else Bigarray_compat.Array1.get t.buffer (t.off+i)
 
 
 external ba_set_int16 : buffer -> int -> uint16 -> unit = "%caml_bigstring_set16u"
@@ -426,7 +426,7 @@ let hexdump_pp fmt t =
   Format.pp_open_vbox fmt 0 ;
   for i = 0 to len t - 1 do
     let column = i mod 16 in
-    let c = Char.code (Bigarray.Array1.get t.buffer (t.off+i)) in
+    let c = Char.code (Bigarray_compat.Array1.get t.buffer (t.off+i)) in
     Format.fprintf fmt "%a%.2x%a" before column c after column
   done ;
   Format.pp_close_box fmt ()

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -136,7 +136,7 @@ val string_to_bar16 : string -> bar16 option
 
 (** {2 Base types } *)
 
-type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+type buffer = (char, Bigarray_compat.int8_unsigned_elt, Bigarray_compat.c_layout) Bigarray_compat.Array1.t
 (** Type of a buffer. A cstruct is composed of an underlying buffer
     and position/length within this buffer. *)
 
@@ -179,7 +179,7 @@ val of_bigarray: ?off:int -> ?len:int -> buffer -> t
 (** [of_bigarray ~off ~len b] is the cstruct contained in [b] starting
     at [off], of length [len]. *)
 
-val to_bigarray: t -> buffer 
+val to_bigarray: t -> buffer
 (** [to_bigarray t] converts a {!t} into a {!buffer} Bigarray, using
     the Bigarray slicing to allocate a fresh array that preserves
     sharing of the underlying buffer. *)
@@ -320,7 +320,7 @@ val blit_to_bytes: t -> int -> bytes -> int -> int -> unit
     a valid substring of [dst]. *)
 
 val blit_to_string: t -> int -> bytes -> int -> int -> unit
-(** [blit_to_string] is a deprecated alias of {!blit_to_bytes}. 
+(** [blit_to_string] is a deprecated alias of {!blit_to_bytes}.
 
     @deprecated This is a deprecated alias of {!blit_to_bytes}. *)
 
@@ -371,7 +371,7 @@ val hexdump_to_buffer: Buffer.t -> t -> unit
 
 val hexdump_pp: Format.formatter -> t -> unit
 (** [hexdump_pp f c] pretty-prints a hexdump of [c] to [f]. *)
- 
+
 val debug: t -> string
 (** [debug t] will print out the internal details of a cstruct such
     as its base offset and the length, and raise an assertion failure

--- a/lib/dune
+++ b/lib/dune
@@ -1,7 +1,7 @@
 (library
  (name cstruct)
  (public_name cstruct)
- (libraries bigarray)
+ (libraries bigarray-compat)
  (c_names cstruct_stubs)
  (js_of_ocaml (javascript_files cstruct.js))
  (modules cstruct))

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,5 +1,5 @@
 (executable
- (libraries cstruct alcotest cstruct-sexp)
+ (libraries cstruct bigarray alcotest cstruct-sexp)
  (name tests))
 
 (alias

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name cstruct_unix)
  (wrapped false)
  (public_name cstruct-unix)
- (libraries cstruct unix))
+ (libraries cstruct bigarray unix))


### PR DESCRIPTION
The bigarray-compat package allows to selectively choose Bigarray or Stdlib.Bigarray according to ocaml version. Stdlib.Bigarray allows to not depend on unix for OCaml >= 4.07.