### PR TITLE
ppx: generate compare functions for cenums

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,16 @@ val int_to_foo32 : int32 -> foo32 option
 val foo32_to_int : foo32 -> int32
 val foo32_to_string : foo32 -> string
 val string_to_foo32 : string -> foo32 option
+val compare_foo32 : foo32 -> foo32 -> int
 type bar16 = | ONE | TWO | FOUR | FIVE
 val int_to_bar16 : int -> bar16 option
 val bar16_to_int : bar16 -> int
 val bar16_to_string : bar16 -> string
 val string_to_bar16 : string -> bar16 option
+val compare_bar16 : bar16 -> bar16 -> int
 ```
+
+Comparisons will be done relatively to the constructor ids.
 
 You can also add a `(sexp)` decorator to output s-expression convertors
 for use with the `sexplib` library.

--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -450,12 +450,15 @@ let declare_enum_expr ({fields; _} as cenum) = function
       ) fields in
     Exp.match_ [%expr x]
       (parsers @ [Exp.case [%pat? _] [%expr None]])
-  | Enum_compare -> [%expr fun y -> Pervasives.compare x y]
+  | Enum_compare -> [%expr fun y ->
+    let to_int = [%e Ast.evar (enum_op_name cenum Enum_set)] in
+    Pervasives.compare (to_int x) (to_int y)
+  ]
 
 let enum_ops_for {sexp; _} =
-  Enum_compare ::
   Enum_get ::
   Enum_set ::
+  Enum_compare ::
   Enum_print ::
   Enum_parse ::
   if sexp then

--- a/ppx_test/enum.ml
+++ b/ppx_test/enum.ml
@@ -63,6 +63,13 @@ type foo8 =
   [@@uint8_t]
 ]
 
+[%%cenum
+type reversed =
+  | ONE_R [@id 2]
+  | TWO_R [@id 1]
+  [@@uint8_t]
+]
+
 let tests () =
   ignore(int_to_foo64 2L);
   ignore(int_to_foo32 1l);
@@ -82,6 +89,7 @@ let tests () =
   assert(foo8_to_string ONE8 = "ONE8");
   assert(compare_foo8 ONE8 TWO8 = -1);
   assert(compare_foo8 TWO8 ONE8 = 1);
-  assert(compare_foo8 TWO8 TWO8 = 0)
+  assert(compare_foo8 TWO8 TWO8 = 0);
+  assert(compare_reversed ONE_R TWO_R = 1)
 
 let () = tests ()

--- a/ppx_test/enum.ml
+++ b/ppx_test/enum.ml
@@ -79,6 +79,9 @@ let tests () =
   assert(int_to_foo32 0xfffffffel = Some (TWO32));
   assert(int_to_foo32 0xffffffffl = Some (THREE32));
   assert(string_to_foo16 "ONE16" = Some ONE16);
-  assert(foo8_to_string ONE8 = "ONE8")
+  assert(foo8_to_string ONE8 = "ONE8");
+  assert(compare_foo8 ONE8 TWO8 = -1);
+  assert(compare_foo8 TWO8 ONE8 = 1);
+  assert(compare_foo8 TWO8 TWO8 = 0)
 
 let () = tests ()


### PR DESCRIPTION
Hi,

This is a patch for #128. This generates an extra `compare_X` function for each cenum. The comparison function corresponds to the id order.

Let me know what you think @yomimono @avsm.

Thanks!