### PR TITLE
mark add_len / set_len as deprecated

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -311,13 +311,13 @@ val blit_from_bytes: bytes -> int -> t -> int -> int -> unit
     designate a valid segment of [dst]. *)
 
 val blit_to_bytes: t -> int -> bytes -> int -> int -> unit
-(** [blit_to_string src srcoff dst dstoff len] copies [len] characters
-    from cstruct [src], starting at index [srcoff], to string [dst],
+(** [blit_to_bytes src srcoff dst dstoff len] copies [len] characters
+    from cstruct [src], starting at index [srcoff], to the [dst] buffer,
     starting at index [dstoff].
 
     @raise Invalid_argument if [srcoff] and [len] do not designate a
     valid segment of [src], or if [dstoff] and [len] do not designate
-    a valid substring of [dst]. *)
+    a valid segment of [dst]. *)
 
 val blit_to_string: t -> int -> bytes -> int -> int -> unit
   [@@ocaml.deprecated "Use blit_to_bytes instead, blit_to_string will be removed in cstruct 5.0.0"]

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -320,9 +320,8 @@ val blit_to_bytes: t -> int -> bytes -> int -> int -> unit
     a valid substring of [dst]. *)
 
 val blit_to_string: t -> int -> bytes -> int -> int -> unit
-(** [blit_to_string] is a deprecated alias of {!blit_to_bytes}.
-
-    @deprecated This is a deprecated alias of {!blit_to_bytes}. *)
+  [@@ocaml.deprecated "Use blit_to_bytes instead, blit_to_string will be removed in cstruct 5.0.0"]
+(** [blit_to_string] is a deprecated alias of {!blit_to_bytes}. *)
 
 val memset: t -> int -> unit
 (** [memset t x] sets all the bytes of [t] to [x land 0xff]. *)
@@ -333,11 +332,13 @@ val len: t -> int
     buffer, as the [sub] or [set_len] functions can construct a smaller view. *)
 
 val set_len : t -> int -> t
+  [@@ocaml.deprecated "This function will be removed in cstruct 5.0.0. If you need this function, discuss other ways in the issue tracker https://github.com/mirage/ocaml-cstruct."]
 (** [set_len t len] sets the length of the cstruct [t] to a new absolute
     value, and returns a fresh cstruct with these settings.
     @raise Invalid_argument if [len] exceeds the size of the buffer. *)
 
 val add_len : t -> int -> t
+  [@@ocaml.deprecated "This function will be removed in cstruct 5.0.0. If you need this function, discuss other ways in the issue tracker https://github.com/mirage/ocaml-cstruct."]
 (** [add_len t l] will add [l] bytes to the length of the buffer, and return
     a fresh cstruct with these settings.
     @raise Invalid_argument if [len] exceeds the size of the buffer. *)


### PR DESCRIPTION
extracted from #245 to stay focused there. I haven't seen any voice for keeping `add_len` and `set_len` -- though there's still work to be done until we can _remove_ these function (as @talex5 listed [here](https://github.com/mirage/ocaml-cstruct/pull/245#issuecomment-476317682)):
Other uses of `set_len` and `add_len` (from e.g. https://github.com/search?q=org%3Amirage+add_len&type=Code):
- [ ] https://github.com/mirage/mirage-block-xen/blob/master/lib/block_request.ml#L67 ("merge adjacent cstruct buffers"; add new cstruct function for this?)
- [x] https://github.com/mirage/ocaml-git/blob/master/src/git/helper.ml#L219 (don't know what this does - @dinosaure?) -- see https://github.com/mirage/ocaml-git/pull/345 which removed it
- [ ] https://github.com/mirage/ocaml-vmnet/blob/38d156580f55404d25d5b76e3343aa418c5ccf56/lib/vmnet.ml (possibly using it as a `truncate`? maybe add a non-deprecated `truncate` function for that?)
- [ ] https://github.com/mirage/ocaml-openflow/blob/dcda113745e8edc61b5508eb8ac2d1e864e1a2df/lib/ofsocket.ml (dead? no updates since 2013)
- [x] https://github.com/mirage/mirage-tcpip/blob/ee3e8a3335c620e311a6d36d55539294a2c64ca6/src/tcp/tcp_packet.ml (used as truncate) -- see https://github.com/mirage/mirage-tcpip/pull/403