### PR TITLE
Suppress deprecation warnings in tests

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -115,7 +115,7 @@ let () =
       check (Cstruct.get_uint8 c i = x land 0xff)
     );
   add_test ~name:"set_len" [cstruct; int] (fun base len ->
-      match Cstruct.set_len base len with
+      match[@ocaml.warning "-3"] Cstruct.set_len base len with
       | x ->
         (* check_within ~base x; *)   (* Maybe deprecate set_len extending the allocation? *)
         check (Cstruct.len x >= 0);
@@ -124,7 +124,7 @@ let () =
       | exception Invalid_argument _ -> ()
     );
   add_test ~name:"add_len" [cstruct; int] (fun base len ->
-      match Cstruct.add_len base len with
+      match[@ocaml.warning "-3"] Cstruct.add_len base len with
       | x ->
         check (Cstruct.len x >= 0);
         check (Cstruct.len x <= Bigarray.Array1.dim (base.Cstruct.buffer));

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -164,28 +164,28 @@ let test_of_bigarray_large_length () =
 let test_set_len_too_big () =
   let x = Cstruct.create 0 in
   try
-    let y = Cstruct.set_len x 1 in
+    let[@ocaml.warning "-3"] y = Cstruct.set_len x 1 in
     failwith (Printf.sprintf "test_set_len_too_big: %s" (to_string y))
   with Invalid_argument _ -> ()
 
 let test_set_len_too_small () =
   let x = Cstruct.create 0 in
   try
-    let y = Cstruct.set_len x (-1) in
+    let[@ocaml.warning "-3"] y = Cstruct.set_len x (-1) in
     failwith (Printf.sprintf "test_set_len_too_small: %s" (to_string y))
   with Invalid_argument _ -> ()
 
 let test_add_len_too_big () =
   let x = Cstruct.create 0 in
   try
-    let y = Cstruct.add_len x 1 in
+    let[@ocaml.warning "-3"] y = Cstruct.add_len x 1 in
     failwith (Printf.sprintf "test_add_len_too_big: %s" (to_string y))
   with Invalid_argument _ -> ()
 
 let test_add_len_too_small () =
   let x = Cstruct.create 0 in
   try
-    let y = Cstruct.add_len x (-1) in
+    let[@ocaml.warning "-3"] y = Cstruct.add_len x (-1) in
     failwith (Printf.sprintf "test_add_len_too_small: %s" (to_string y))
   with Invalid_argument _ -> ()
 


### PR DESCRIPTION
This ensures that `make test` works.

And these tests will be deleted with the corresponding functions are.