### PR TITLE
len attribute should be an int literal

### DIFF
--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -527,12 +527,17 @@ let constr_enum = function
     loc_err loc "invalid cenum variant"
 
 let get_len = function
-  | [ ({txt = "len"; _},
+  | [ ({txt = "len"; loc},
        PStr
          [{pstr_desc =
              Pstr_eval ({pexp_desc = Pexp_constant (Pconst_integer (sz, None)); _}, _)
-          ; _}])] ->
-    Some (int_of_string sz)
+          ; _}])]
+    ->
+    let n = int_of_string sz in
+    if n > 0 then
+      Some n
+    else
+      loc_err loc "[@len] argument should be > 0"
   | [{txt = "len"; loc}, _ ] ->
     loc_err loc "[@len] argument should be an integer"
   | _ ->

--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -526,15 +526,20 @@ let constr_enum = function
   | {pcd_loc = loc; _} ->
     loc_err loc "invalid cenum variant"
 
+let get_len = function
+  | [ ({txt = "len"; _},
+       PStr
+         [{pstr_desc =
+             Pstr_eval ({pexp_desc = Pexp_constant (Pconst_integer (sz, None)); _}, _)
+          ; _}])] ->
+    Some (int_of_string sz)
+  | [{txt = "len"; loc}, _ ] ->
+    loc_err loc "[@len] argument should be an integer"
+  | _ ->
+    None
+
 let constr_field {pld_name = fname; pld_type = fty; pld_loc = loc; pld_attributes = att; _} =
-  let get = function
-    | [{txt = "len"; _}, PStr
-         [{pstr_desc = Pstr_eval ({pexp_desc = Pexp_constant (Pconst_integer(sz, _)); _}, _); _}]] ->
-      Some (int_of_string sz)
-    | _ ->
-      None
-  in
-  let sz = match get fty.ptyp_attributes, get att with
+  let sz = match get_len fty.ptyp_attributes, get_len att with
   | Some sz, None
   | None, Some sz -> Some sz
   | Some _, Some _ -> loc_err loc "multiple field length attribute"

--- a/ppx_test/errors/cstruct_len_int32.ml
+++ b/ppx_test/errors/cstruct_len_int32.ml
@@ -1,0 +1,6 @@
+[%%cstruct
+  type t = {
+    a: uint8_t [@len 8l]
+  }
+  [@@little_endian]
+]

--- a/ppx_test/errors/cstruct_len_int32.ml.expected
+++ b/ppx_test/errors/cstruct_len_int32.ml.expected
@@ -1,0 +1,2 @@
+File "cstruct_len_int32.ml", line 3, characters 17-20:
+Error: ppx_cstruct: [@len] argument should be an integer

--- a/ppx_test/errors/cstruct_len_not_int.ml
+++ b/ppx_test/errors/cstruct_len_not_int.ml
@@ -1,0 +1,6 @@
+[%%cstruct
+  type t = {
+    a: uint8_t [@len ""]
+  }
+  [@@little_endian]
+]

--- a/ppx_test/errors/cstruct_len_not_int.ml.expected
+++ b/ppx_test/errors/cstruct_len_not_int.ml.expected
@@ -1,0 +1,2 @@
+File "cstruct_len_not_int.ml", line 3, characters 17-20:
+Error: ppx_cstruct: [@len] argument should be an integer

--- a/ppx_test/errors/cstruct_len_zero.ml
+++ b/ppx_test/errors/cstruct_len_zero.ml
@@ -1,0 +1,6 @@
+[%%cstruct
+  type t = {
+    a: uint8_t [@len 0]
+  }
+  [@@little_endian]
+]

--- a/ppx_test/errors/cstruct_len_zero.ml.expected
+++ b/ppx_test/errors/cstruct_len_zero.ml.expected
@@ -1,0 +1,2 @@
+File "cstruct_len_zero.ml", line 3, characters 17-20:
+Error: ppx_cstruct: [@len] argument should be > 0

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -98,6 +98,34 @@
     (diff cstruct_duplicate_field.ml.expected cstruct_duplicate_field.ml.errors)))
 
 (rule
+  (deps pp.exe (:input cstruct_len_int32.ml))
+  (targets cstruct_len_int32.ml.errors)
+  (action
+    (with-stderr-to
+      %{targets}
+      (run ./pp.exe --impl %{input}))))
+
+(alias
+  (name runtest)
+  (package ppx_cstruct)
+  (action
+    (diff cstruct_len_int32.ml.expected cstruct_len_int32.ml.errors)))
+
+(rule
+  (deps pp.exe (:input cstruct_len_not_int.ml))
+  (targets cstruct_len_not_int.ml.errors)
+  (action
+    (with-stderr-to
+      %{targets}
+      (run ./pp.exe --impl %{input}))))
+
+(alias
+  (name runtest)
+  (package ppx_cstruct)
+  (action
+    (diff cstruct_len_not_int.ml.expected cstruct_len_not_int.ml.errors)))
+
+(rule
   (deps pp.exe (:input cstruct_multiple_len.ml))
   (targets cstruct_multiple_len.ml.errors)
   (action

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -126,6 +126,20 @@
     (diff cstruct_len_not_int.ml.expected cstruct_len_not_int.ml.errors)))
 
 (rule
+  (deps pp.exe (:input cstruct_len_zero.ml))
+  (targets cstruct_len_zero.ml.errors)
+  (action
+    (with-stderr-to
+      %{targets}
+      (run ./pp.exe --impl %{input}))))
+
+(alias
+  (name runtest)
+  (package ppx_cstruct)
+  (action
+    (diff cstruct_len_zero.ml.expected cstruct_len_zero.ml.errors)))
+
+(rule
   (deps pp.exe (:input cstruct_multiple_len.ml))
   (targets cstruct_multiple_len.ml.errors)
   (action


### PR DESCRIPTION
Closes #264

This rejects things like `[@len ""]` and `[@len 1l]` which were previously silently ignored.