### PR TITLE
PPX: Use Stdlib instead of Pervasives for generated enum compare functions

### DIFF
--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -452,7 +452,7 @@ let declare_enum_expr ({fields; _} as cenum) = function
     Exp.function_ (parsers @ [Exp.case [%pat? _] [%expr None]])
   | Enum_compare -> [%expr fun x y ->
     let to_int = [%e Ast.evar (enum_op_name cenum Enum_set)] in
-    Pervasives.compare (to_int x) (to_int y)
+    Stdlib.compare (to_int x) (to_int y)
   ]
 
 let enum_ops_for {sexp; _} =


### PR DESCRIPTION
Currently, when using the `[%%cenum...]` PPX extension on OCaml 4.08, compilation fails with the error:

```
Error (alert deprecated): module Stdlib.Pervasives
Use Stdlib instead.

If you need to stay compatible with OCaml < 4.07, you can use the 
stdlib-shims library: https://github.com/ocaml/stdlib-shims
```

This change switches the generated code to use Stdlib.compare instead of Pervasives.compare. Of course, this will break compatibility in OCaml < 4.07, but as noted in the error message, users of older compilers could use the stdlib-shims.

Depending on your compatibility plans, a note should be added to the README. Maybe it's possible to add this directly to the ppx_cstruct dependencies in the .opam file (with a version restriction on the compiler)?