### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "async_kernel" {>= "v0.9.0" & < "v0.13"}
   "async_unix" {>= "v0.9.0" & < "v0.13"}
   "core_kernel" {>= "v0.9.0" & < "v0.13"}

--- a/cstruct-lwt.opam
+++ b/cstruct-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "base-unix"
   "lwt"
   "cstruct" {=version}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "sexplib" {< "v0.13"}
   "cstruct" {>= "3.6.0"}
   "alcotest" {with-test}

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "base-unix"
   "cstruct" {=version}
 ]

--- a/cstruct.opam
+++ b/cstruct.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "bigarray-compat"
   "alcotest" {with-test}
 ]

--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {=version}
   "ounit" {with-test}
   "ppx_tools_versioned" {>= "5.0.1"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.