### PR TITLE
Update jsoo runtime with missing primitives

### DIFF
--- a/lib/cstruct.js
+++ b/lib/cstruct.js
@@ -15,14 +15,16 @@
  */
 
 //Provides: caml_blit_bigstring_to_bigstring
-//Requires: caml_ba_get_1, caml_ba_set_1
-function caml_blit_bigstring_to_bigstring(src, src_off, dst, dst_off, len) {
-  var i;
-  for (i = 0; i < len; i++) {
-    caml_ba_set_1(dst, dst_off + i, caml_ba_get_1(src, src_off + i));
-  }
-  return 0;
-}
+//Requires: caml_bigstring_blit_ba_to_ba
+var caml_blit_bigstring_to_bigstring = caml_bigstring_blit_ba_to_ba
+
+//Provides: caml_blit_bigstring_to_string
+//Requires: caml_bigstring_blit_ba_to_bytes
+var caml_blit_bigstring_to_string = caml_bigstring_blit_ba_to_bytes
+
+//Provides: caml_blit_string_to_bigstring
+//Requires: caml_bigstring_blit_string_to_ba
+var caml_blit_string_to_bigstring = caml_bigstring_blit_string_to_ba
 
 //Provides: caml_compare_bigstring
 //Requires: caml_int_compare, caml_ba_get_1


### PR DESCRIPTION
and use optimized blit functions provided by jsoo.

One should wait for the 3 jsoo PR to be merged and released first.
- [x] https://github.com/ocsigen/js_of_ocaml/pull/879
- [x] https://github.com/ocsigen/js_of_ocaml/pull/883
- [x] https://github.com/ocsigen/js_of_ocaml/pull/884