### PR TITLE
Refine CI test matrix and opam updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,32 @@ name: Cstruct
 on: [push]
 jobs:
   run:
-    name: T
+    name: Older
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ocaml-version: [ '4.05.0', '4.04.2', '4.03.0' ]
+    steps:
+    - uses: actions/checkout@master
+    - uses: avsm/setup-ocaml@v1.0
+      with:
+        ocaml-version: ${{ matrix.ocaml-version }}
+    - run: opam pin add -n cstruct.dev .
+    - name: Packages
+      run: opam depext -yt cstruct
+    - name: Dependencies
+      run: opam install cstruct --deps-only
+    - name: Build
+      run: opam exec -- dune build -p cstruct
+    - name: Test
+      run: opam exec -- dune runtest -p cstruct
+  run:
+    name: Latest
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml-version: [ '4.08.1', '4.07.1', '4.06.1', '4.05.0', '4.04.0', '4.03.0' ]
+        ocaml-version: [ '4.08.1', '4.07.1', '4.06.1' ]
     steps:
     - uses: actions/checkout@master
     - uses: avsm/setup-ocaml@v1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Cstruct
-on: [push]
+on: [push, pull_request]
 jobs:
   run:
     name: Older

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Cstruct
 on: [push, pull_request]
 jobs:
-  run:
+  older:
     name: Older
     runs-on: ubuntu-latest
     strategy:
@@ -21,7 +21,7 @@ jobs:
       run: opam exec -- dune build -p cstruct
     - name: Test
       run: opam exec -- dune runtest -p cstruct
-  run:
+  latest:
     name: Latest
     runs-on: ${{ matrix.operating-system }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         ocaml-version: ${{ matrix.ocaml-version }}
     - run: opam pin add -n .
     - name: Packages
-      run: opam depext -yt cstruct cstruct-sexp cstruct-unix cstruct-async cstruct-lwt
+      run: opam depext -yt cstruct cstruct-sexp cstruct-unix cstruct-lwt
     - name: Dependencies
       run: opam install -t . --deps-only
     - name: Build
@@ -44,3 +44,20 @@ jobs:
       run: opam exec -- dune runtest
     - name: Install
       run: opam install .
+  async:
+    name: Async
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        ocaml-version: [ '4.08.1', '4.07.1', '4.06.1' ]
+        operating-system: [macos-latest, ubuntu-latest]
+    steps:
+    - uses: actions/checkout@master
+    - uses: avsm/setup-ocaml@v1.0
+      with:
+        ocaml-version: ${{ matrix.ocaml-version }}
+    - run: opam pin add -n .
+    - name: Packages
+      run: opam depext -yt cstruct-async 
+    - name: Dependencies
+      run: opam install -t cstruct-async

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [macos-latest, ubuntu-latest, windows-latest]
         ocaml-version: [ '4.08.1', '4.07.1', '4.06.1' ]
+        operating-system: [macos-latest, ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@master
     - uses: avsm/setup-ocaml@v1.0

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -15,10 +15,10 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
-  "async_kernel" {>= "v0.9.0" & < "v0.13"}
-  "async_unix" {>= "v0.9.0" & < "v0.13"}
-  "core_kernel" {>= "v0.9.0" & < "v0.13"}
+  "dune"
+  "async_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.9.0"}
   "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/cstruct-lwt.opam
+++ b/cstruct-lwt.opam
@@ -16,9 +16,9 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
+  "dune"
   "lwt"
   "cstruct" {=version}
-  "dune" {build & >= "1.0"}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -17,9 +17,9 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
-  "sexplib" {< "v0.13"}
-  "cstruct" {>= "3.6.0"}
+  "dune"
+  "sexplib"
+  "cstruct" {=version}
   "alcotest" {with-test}
 ]
 synopsis: "S-expression serialisers for C-like structures"

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune" {build & >= "1.0"}
+  "dune"
   "base-unix"
   "cstruct" {=version}
 ]

--- a/cstruct.opam
+++ b/cstruct.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build & >= "1.0"}
+  "dune"
   "bigarray-compat"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
- Test just the core cstruct package on older compilers
- Test full matrix on latest three compilers
- Update opam files to remove dune `build` and stricter cstruct
  deps to match upstream opam-repository