### PR TITLE
Upgrade ocaml-migrate-parsetree to support latest ocaml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,15 +6,15 @@ platform:
   arch: amd64
 
 steps:
-- name: build
-  image: ocaml/opam2:4.08
-  commands:
-  - sudo apt-get update && sudo apt-get -y install afl
-  - sudo chown -R opam .
-  - git -C /home/opam/opam-repository pull origin && opam update
-  - opam switch 4.08+afl
-  - opam pin add -n .
-  - opam depext -u cstruct-async cstruct-lwt cstruct-unix cstruct ppx_cstruct
-  - opam install -y .
-  - opam install -y dune.1.11.4 crowbar fmt bun
-  - opam exec -- dune build @fuzz --no-buffer
+  - name: build
+    image: ocaml/opam2:4.08
+    commands:
+      - sudo apt-get update && sudo apt-get -y install afl
+      - sudo chown -R opam .
+      - git -C /home/opam/opam-repository pull origin && opam update
+      - opam switch 4.08+afl
+      - opam pin add -n .
+      - opam depext -u cstruct-async cstruct-lwt cstruct-unix cstruct ppx_cstruct
+      - opam install -y .
+      - opam install -y dune crowbar fmt bun
+      - opam exec -- dune build @fuzz --no-buffer

--- a/cstruct-async.opam
+++ b/cstruct-async.opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "async_kernel" {>= "v0.9.0"}
   "async_unix" {>= "v0.9.0"}
   "core_kernel" {>= "v0.9.0"}

--- a/cstruct-lwt.opam
+++ b/cstruct-lwt.opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base-unix"
-  "dune"
+  "dune" {>= "2.0.0"}
   "lwt"
   "cstruct" {=version}
 ]

--- a/cstruct-sexp.opam
+++ b/cstruct-sexp.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}  
   "sexplib"
   "cstruct" {=version}
   "alcotest" {with-test}

--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "base-unix"
   "cstruct" {=version}
 ]

--- a/cstruct.opam
+++ b/cstruct.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "bigarray-compat"
   "alcotest" {with-test}
 ]

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,5 @@
-(lang dune 1.0)
+(lang dune 2.0)
+
+(allow_approximate_merlin)
+
 (name cstruct)

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -2,10 +2,11 @@
  (name fuzz)
  (libraries cstruct bigarray cstruct-sexp crowbar fmt))
 
-(alias
- (name fuzz)
- (deps fuzz.exe (source_tree input))
- (action (run
-    timeout --preserve-status 50m
-    bun -v --input=input --output=output
-    -- ./fuzz.exe)))
+(rule
+ (alias fuzz)
+ (deps
+  fuzz.exe
+  (source_tree input))
+ (action
+  (run timeout --preserve-status 50m bun -v --input=input --output=output --
+    ./fuzz.exe)))

--- a/lib/dune
+++ b/lib/dune
@@ -2,9 +2,12 @@
  (name cstruct)
  (public_name cstruct)
  (libraries bigarray-compat)
- (c_names cstruct_stubs)
+ (foreign_stubs
+  (language c)
+  (names cstruct_stubs))
  (wrapped false)
- (js_of_ocaml (javascript_files cstruct.js))
+ (js_of_ocaml
+  (javascript_files cstruct.js))
  (modules cstruct cstruct_cap))
 
 (library

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -2,8 +2,8 @@
  (libraries cstruct bigarray alcotest cstruct-sexp)
  (name tests))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (package cstruct-sexp)
  (action
   (run ./tests.exe -e)))

--- a/ppx/dune
+++ b/ppx/dune
@@ -5,6 +5,6 @@
  (wrapped false)
  (ppx_runtime_libraries cstruct stdlib-shims)
  (preprocess
-  (pps ppx_tools_versioned.metaquot_404))
+  (pps ppx_tools_versioned.metaquot_411))
  (libraries sexplib ocaml-migrate-parsetree ppx_tools_versioned
-   ppx_tools_versioned.metaquot_404 bigarray stdlib-shims))
+   ppx_tools_versioned.metaquot_411 bigarray stdlib-shims))

--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "cstruct" {=version}
   "ounit" {with-test}
   "ppx_tools_versioned" {>= "5.0.1"}

--- a/ppx_test/errors/dune
+++ b/ppx_test/errors/dune
@@ -1,23 +1,27 @@
 (executable
-  (name pp)
-  (modules pp)
-  (preprocess (action
-    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
-  (libraries
-    ppx_cstruct
-    ocaml-migrate-parsetree))
+ (name pp)
+ (modules pp)
+ (preprocess
+  (action
+   (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))
+ (libraries ppx_cstruct ocaml-migrate-parsetree))
 
 (executable
-  (name gen_tests)
-  (modules gen_tests))
+ (name gen_tests)
+ (modules gen_tests))
 
 (include dune.inc)
 
 (rule
  (targets dune.inc.gen)
- (deps (source_tree .))
- (action (with-stdout-to %{targets} (run ./gen_tests.exe))))
+ (deps
+  (source_tree .))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run ./gen_tests.exe))))
 
-(alias
- (name runtest)
- (action (diff dune.inc dune.inc.gen)))
+(rule
+ (alias runtest)
+ (action
+  (diff dune.inc dune.inc.gen)))

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -7,8 +7,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cenum_id_payload.ml.expected cenum_id_payload.ml.errors)))
@@ -21,8 +21,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cenum_invalid_type.ml.expected cenum_invalid_type.ml.errors)))
@@ -35,8 +35,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cenum_no_attribute.ml.expected cenum_no_attribute.ml.errors)))
@@ -49,8 +49,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cenum_not_a_variant.ml.expected cenum_not_a_variant.ml.errors)))
@@ -63,8 +63,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cenum_unknown_attribute.ml.expected cenum_unknown_attribute.ml.errors)))
@@ -77,8 +77,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_attribute_payload.ml.expected cstruct_attribute_payload.ml.errors)))
@@ -91,8 +91,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_duplicate_field.ml.expected cstruct_duplicate_field.ml.errors)))
@@ -105,8 +105,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_len_int32.ml.expected cstruct_len_int32.ml.errors)))
@@ -119,8 +119,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_len_not_int.ml.expected cstruct_len_not_int.ml.errors)))
@@ -133,8 +133,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_len_zero.ml.expected cstruct_len_zero.ml.errors)))
@@ -147,8 +147,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_multiple_len.ml.expected cstruct_multiple_len.ml.errors)))
@@ -161,8 +161,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_not_a_record.ml.expected cstruct_not_a_record.ml.errors)))
@@ -175,8 +175,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_not_an_identifier.ml.expected cstruct_not_an_identifier.ml.errors)))
@@ -189,8 +189,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_several_attributes.ml.expected cstruct_several_attributes.ml.errors)))
@@ -203,8 +203,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_unknown_endian.ml.expected cstruct_unknown_endian.ml.errors)))
@@ -217,8 +217,8 @@
       %{targets}
       (run ./pp.exe --impl %{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff cstruct_unknown_type.ml.expected cstruct_unknown_type.ml.errors)))

--- a/ppx_test/errors/gen_tests.ml
+++ b/ppx_test/errors/gen_tests.ml
@@ -9,8 +9,8 @@ let output_stanzas name =
       %%{targets}
       (run ./pp.exe --impl %%{input}))))
 
-(alias
-  (name runtest)
+(rule
+  (alias runtest)
   (package ppx_cstruct)
   (action
     (diff %s.expected %s.errors)))

--- a/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
+++ b/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
@@ -10,5 +10,6 @@ type foo64 =
   [@@uint64_t]
 ]
 
-let foo = Lwt_main.run (Lwt.return ())
-
+let foo = 
+  let%lwt foo = Lwt.return () in 
+  Lwt.return foo

--- a/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
+++ b/ppx_test/with-lwt/ppx_cstruct_and_lwt.ml
@@ -10,5 +10,5 @@ type foo64 =
   [@@uint64_t]
 ]
 
-let%lwt foo = Lwt.return ()
+let foo = Lwt_main.run (Lwt.return ())
 

--- a/ppx_test/with-sexp/dune
+++ b/ppx_test/with-sexp/dune
@@ -1,10 +1,11 @@
 (executable
  (name ppx_cstruct_and_sexp)
- (preprocess (pps ppx_cstruct ppx_sexp_conv -- -no-check))
+ (preprocess
+  (pps ppx_cstruct ppx_sexp_conv -- -no-check))
  (libraries cstruct sexplib cstruct-sexp))
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (package ppx_cstruct)
  (action
   (run ./ppx_cstruct_and_sexp.exe)))


### PR DESCRIPTION
This PR upgrades the ocaml-migrate-parsetree to the latest version supporting ocaml up to version 4.11.

The PR also upgrades dune to v2.0 to address some dune warnings. 

All tests pass. 