### PR TITLE
ppx_tests: preprocess output to remove file id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ env:
   - PACKAGE="cstruct"       DISTRO="alpine"   OCAML_VERSION="4.07"
   - PACKAGE="cstruct-lwt"   DISTRO="debian-testing"  OCAML_VERSION="4.07"
   - PACKAGE="cstruct-async" DISTRO="centos"   OCAML_VERSION="4.07"
-  - PACKAGE="ppx_cstruct"   DISTRO="debian-unstable" OCAML_VERSION="4.07"
+  - PACKAGE="ppx_cstruct"   DISTRO="debian-stable" OCAML_VERSION="4.07"
   - PACKAGE="cstruct-unix"  DISTRO="ubuntu"          OCAML_VERSION="4.07"
   - PACKAGE="cstruct-unix"  DISTRO="alpine"          OCAML_VERSION="4.08"

--- a/ppx_test/errors/cenum_id_payload.ml.expected
+++ b/ppx_test/errors/cenum_id_payload.ml.expected
@@ -1,2 +1,1 @@
-File "cenum_id_payload.ml", line 2, characters 18-20:
 Error: ppx_cstruct: invalid id

--- a/ppx_test/errors/cenum_invalid_type.ml.expected
+++ b/ppx_test/errors/cenum_invalid_type.ml.expected
@@ -1,2 +1,1 @@
-File "cenum_invalid_type.ml", line 2, characters 11-19:
 Error: ppx_cstruct: invalid cenum variant

--- a/ppx_test/errors/cenum_no_attribute.ml.expected
+++ b/ppx_test/errors/cenum_no_attribute.ml.expected
@@ -1,2 +1,1 @@
-File "cenum_no_attribute.ml", line 2, characters 2-18:
 Error: ppx_cstruct: invalid cenum attributes

--- a/ppx_test/errors/cenum_not_a_variant.ml.expected
+++ b/ppx_test/errors/cenum_not_a_variant.ml.expected
@@ -1,2 +1,1 @@
-File "cenum_not_a_variant.ml", line 2, characters 2-34:
 Error: ppx_cstruct: expected variant type

--- a/ppx_test/errors/cenum_unknown_attribute.ml.expected
+++ b/ppx_test/errors/cenum_unknown_attribute.ml.expected
@@ -1,2 +1,1 @@
-File "cenum_unknown_attribute.ml", line 2, characters 2-32:
 Error: ppx_cstruct: enum: unknown width specifier uint9_t

--- a/ppx_test/errors/cstruct_attribute_payload.ml.expected
+++ b/ppx_test/errors/cstruct_attribute_payload.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_attribute_payload.ml", line 2, characters 2-57:
 Error: ppx_cstruct: no attribute payload expected

--- a/ppx_test/errors/cstruct_duplicate_field.ml.expected
+++ b/ppx_test/errors/cstruct_duplicate_field.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_duplicate_field.ml", line 5, characters 2-14:
 Error: ppx_cstruct: field x is present several times in this type

--- a/ppx_test/errors/cstruct_len_int32.ml.expected
+++ b/ppx_test/errors/cstruct_len_int32.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_len_int32.ml", line 3, characters 17-20:
 Error: ppx_cstruct: [@len] argument should be an integer

--- a/ppx_test/errors/cstruct_len_not_int.ml.expected
+++ b/ppx_test/errors/cstruct_len_not_int.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_len_not_int.ml", line 3, characters 17-20:
 Error: ppx_cstruct: [@len] argument should be an integer

--- a/ppx_test/errors/cstruct_len_zero.ml.expected
+++ b/ppx_test/errors/cstruct_len_zero.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_len_zero.ml", line 3, characters 17-20:
 Error: ppx_cstruct: [@len] argument should be > 0

--- a/ppx_test/errors/cstruct_multiple_len.ml.expected
+++ b/ppx_test/errors/cstruct_multiple_len.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_multiple_len.ml", line 3, characters 4-35:
 Error: ppx_cstruct: multiple field length attribute

--- a/ppx_test/errors/cstruct_not_a_record.ml.expected
+++ b/ppx_test/errors/cstruct_not_a_record.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_not_a_record.ml", line 2, characters 2-14:
 Error: ppx_cstruct: record type declaration expected

--- a/ppx_test/errors/cstruct_not_an_identifier.ml.expected
+++ b/ppx_test/errors/cstruct_not_an_identifier.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_not_an_identifier.ml", line 3, characters 8-20:
 Error: ppx_cstruct: type identifier expected

--- a/ppx_test/errors/cstruct_several_attributes.ml.expected
+++ b/ppx_test/errors/cstruct_several_attributes.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_several_attributes.ml", line 2, characters 2-71:
 Error: ppx_cstruct: too many attributes

--- a/ppx_test/errors/cstruct_unknown_endian.ml.expected
+++ b/ppx_test/errors/cstruct_unknown_endian.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_unknown_endian.ml", line 2, characters 2-49:
 Error: ppx_cstruct: unknown endian unknown_endian, should be little_endian, big_endian, host_endian or bi_endian

--- a/ppx_test/errors/cstruct_unknown_type.ml.expected
+++ b/ppx_test/errors/cstruct_unknown_type.ml.expected
@@ -1,2 +1,1 @@
-File "cstruct_unknown_type.ml", line 3, characters 4-15:
 Error: ppx_cstruct: Unknown type uint9_t

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -3,10 +3,10 @@
   (deps pp.exe (:input cenum_id_payload.ml))
   (targets cenum_id_payload.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -17,10 +17,10 @@
   (deps pp.exe (:input cenum_invalid_type.ml))
   (targets cenum_invalid_type.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -31,10 +31,10 @@
   (deps pp.exe (:input cenum_no_attribute.ml))
   (targets cenum_no_attribute.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -45,10 +45,10 @@
   (deps pp.exe (:input cenum_not_a_variant.ml))
   (targets cenum_not_a_variant.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -59,10 +59,10 @@
   (deps pp.exe (:input cenum_unknown_attribute.ml))
   (targets cenum_unknown_attribute.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -73,10 +73,10 @@
   (deps pp.exe (:input cstruct_attribute_payload.ml))
   (targets cstruct_attribute_payload.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -87,10 +87,10 @@
   (deps pp.exe (:input cstruct_duplicate_field.ml))
   (targets cstruct_duplicate_field.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -101,10 +101,10 @@
   (deps pp.exe (:input cstruct_len_int32.ml))
   (targets cstruct_len_int32.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -115,10 +115,10 @@
   (deps pp.exe (:input cstruct_len_not_int.ml))
   (targets cstruct_len_not_int.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -129,10 +129,10 @@
   (deps pp.exe (:input cstruct_len_zero.ml))
   (targets cstruct_len_zero.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -143,10 +143,10 @@
   (deps pp.exe (:input cstruct_multiple_len.ml))
   (targets cstruct_multiple_len.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -157,10 +157,10 @@
   (deps pp.exe (:input cstruct_not_a_record.ml))
   (targets cstruct_not_a_record.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -171,10 +171,10 @@
   (deps pp.exe (:input cstruct_not_an_identifier.ml))
   (targets cstruct_not_an_identifier.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -185,10 +185,10 @@
   (deps pp.exe (:input cstruct_several_attributes.ml))
   (targets cstruct_several_attributes.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -199,10 +199,10 @@
   (deps pp.exe (:input cstruct_unknown_endian.ml))
   (targets cstruct_unknown_endian.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)
@@ -213,10 +213,10 @@
   (deps pp.exe (:input cstruct_unknown_type.ml))
   (targets cstruct_unknown_type.ml.errors)
   (action
-    (with-stderr-to
-      %{targets}
-      (run ./pp.exe --impl %{input}))))
-
+    (progn
+      (with-stderr-to %{targets}
+        (run ./pp.exe --impl %{input}))
+      (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)

--- a/ppx_test/errors/gen_tests.ml
+++ b/ppx_test/errors/gen_tests.ml
@@ -5,10 +5,10 @@ let output_stanzas name =
   (deps pp.exe (:input %s))
   (targets %s.errors)
   (action
-    (with-stderr-to
-      %%{targets}
-      (run ./pp.exe --impl %%{input}))))
-
+    (progn
+      (with-stderr-to %%{targets}
+        (run ./pp.exe --impl %%{input}))
+      (bash "sed -i.bak '1d' %%{targets}"))))
 (rule
   (alias runtest)
   (package ppx_cstruct)


### PR DESCRIPTION
We primarily just want to check in the ppx unit tests that the
error message is correct. The line number information varies
by compiler version, so we just preprocess to remove that.

In the longer term, this can be fixed more systematically by
using the toplevel_expect_tests package (suggested by @jeremiedimino)
but this PR unblocks the release.