### PR TITLE
Add a middle-step to decode a format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Packages
       run: opam depext -yt cstruct
     - name: Dependencies
-      run: opam install cstruct --deps-only
+      run: opam install -t cstruct --deps-only
     - name: Build
       run: opam exec -- dune build -p cstruct
     - name: Test

--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -539,3 +539,391 @@ let rev t =
     set_uint8 out i_dst byte
   done;
   out
+
+(* Convenience function. *)
+
+external unsafe_blit_string_to_bigstring
+  : string -> int -> buffer -> int -> int -> unit
+  = "caml_blit_string_to_bigstring"
+[@@noalloc]
+
+let get { buffer; off; len; } zidx =
+  if zidx < 0 || zidx >= len then invalid_arg "index out of bounds" ;
+  Bigarray_compat.Array1.get buffer (off + zidx)
+
+let get_byte { buffer; off; len; } zidx =
+  if zidx < 0 || zidx >= len then invalid_arg "index out of bounds" ;
+  Char.code (Bigarray_compat.Array1.get buffer (off + zidx))
+
+let string ?(off= 0) ?len str =
+  let str_len = String.length str in
+  let len = match len with None -> str_len | Some len -> len in
+  if off < 0 || len < 0 || off + len > str_len then invalid_arg "index out of bounds" ;
+  let buffer = Bigarray_compat.(Array1.create char c_layout str_len) in
+  unsafe_blit_string_to_bigstring str 0 buffer 0 str_len ;
+  of_bigarray ~off ~len buffer
+
+let buffer ?(off= 0) ?len buffer =
+  let buffer_len = Bigarray_compat.Array1.dim buffer in
+  let len = match len with None -> buffer_len - off | Some len -> len in
+  if off < 0 || len < 0 || off + len > buffer_len then invalid_arg "index out of bounds" ;
+  of_bigarray ~off ~len buffer
+
+let length cs = len cs
+let start_pos { off; _ } = off
+let stop_pos { off; len; _ } = off + len
+
+let head ?(rev= false) ({ len; _ } as cs) =
+  if len = 0 then None
+  else Some (get_char cs (if rev then len - 1 else 0))
+
+let tail ?(rev= false) ({ buffer; off; len; } as cs) =
+  if len = 0 then cs
+  else if rev then of_bigarray ~off ~len:(len - 2) buffer
+  else of_bigarray ~off:(off + 1) ~len:(len - 1) buffer
+
+let is_empty { len; _ } = len = 0
+
+let is_prefix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx = alen - 1 in
+    let rec loop i =
+      if i > max_zidx then true
+      else if get_char affix i <> get_char cs i
+      then false else loop (succ i) in
+    loop 0
+
+let is_infix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx_a = alen - 1 in
+    let max_zidx_s = len - alen in
+    let rec loop i k =
+      if i > max_zidx_s then false
+      else if k > max_zidx_a then true
+      else if k > 0 then
+        if get_char affix k = get_char cs (i + k)
+        then loop i (succ k)
+        else loop (succ i) 0
+      else if get_char affix 0 = get_char cs i
+      then loop i 1
+      else loop (succ i) 0 in
+    loop 0 0
+
+let is_suffix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx = alen - 1 in
+    let max_zidx_a = alen - 1 in
+    let max_zidx_s = len - 1 in
+    let rec loop i =
+      if i > max_zidx then true
+      else if get_char affix (max_zidx_a - i) <> get_char cs (max_zidx_s - i)
+      then false else loop (succ i) in
+    loop 0
+
+let for_all sat cs =
+  let rec go acc i =
+    if i < len cs
+    then go (sat (get_char cs i) && acc) (succ i)
+    else acc in
+  go true 0
+
+let exists sat cs =
+  let rec go acc i =
+    if i < len cs
+    then go (sat (get_char cs i) || acc) (succ i)
+    else acc in
+  go false 0
+
+let start { buffer; off; _ } =
+  of_bigarray buffer ~off ~len:0
+
+let stop { buffer; off; len; } =
+  of_bigarray buffer ~off:(off + len) ~len:0
+
+let is_white = function ' ' | '\t' .. '\r' -> true | _ -> false
+
+let trim ?(drop = is_white) ({ buffer; off; len; } as cs) =
+  if len = 0 then cs
+  else
+    let max_zpos = len in
+    let max_zidx = len - 1 in
+    let rec left_pos i =
+      if i > max_zidx then max_zpos
+      else if drop (get_char cs i) then left_pos (succ i) else i in
+    let rec right_pos i =
+      if i < 0 then 0
+      else if drop (get_char cs i) then right_pos (pred i) else succ i in
+    let left = left_pos 0 in
+    if left = max_zpos
+    then of_bigarray buffer ~off:((off * 2 + len) / 2) ~len:0
+    else
+      let right = right_pos max_zidx in
+      if left = 0 && right = max_zpos then cs
+      else of_bigarray buffer ~off:(off + left) ~len:(right - left)
+
+let fspan ~min ~max ~sat ({ buffer= v; off; len; } as cs) =
+  if min < 0 then invalid_arg "span: negative min" ;
+  if max < 0 then invalid_arg "span: negative max" ;
+  if min > max || max = 0 then (buffer ~off:off ~len:0 v, cs)
+  else
+    let max_zidx = len - 1 in
+    let max_zidx =
+      let k = max - 1 in
+      if k > max_zidx || k < 0 then max_zidx else k in
+    let need_zidx = min in
+    let rec loop i =
+      if i <= max_zidx && sat (get_char cs i) then loop (i + 1)
+      else if i < need_zidx || i = 0 then buffer ~off:off ~len:0 v, cs
+      else if i = len then (cs, buffer ~off:(off + len) ~len:0 v)
+      else buffer ~off:off ~len:i v, buffer ~off:(off + i) ~len:(len - i) v in
+    loop 0
+
+let rspan ~min ~max ~sat ({ buffer= v; off; len; } as cs) =
+  if min < 0 then invalid_arg "span: negative min" ;
+  if max < 0 then invalid_arg "span: negative max" ;
+  if min > max || max = 0 then (cs, buffer ~off:(off + len) ~len:0 v)
+  else
+    let max_zidx = len - 1 in
+    let min_zidx =
+      let k = len - max in if k < 0 then 0 else k in
+    let need_zidx = len - min - 1 in
+    let rec loop i =
+      if i >= min_zidx && sat (get_char cs i) then loop (i - 1)
+      else if i > need_zidx || i = max_zidx then (cs, buffer ~off:(off + len) ~len:0 v)
+      else if i < 0 then (buffer ~off:off ~len:0 v, cs)
+      else (buffer ~off:off ~len:(i + 1) v, buffer ~off:(off + i + 1) ~len:(len - (i + 1)) v) in
+    loop max_zidx
+
+let span ?(rev= false) ?(min= 0) ?(max= max_int) ?(sat= fun _ -> true) cs =
+  match rev with
+  | true  -> rspan ~min ~max ~sat cs
+  | false -> fspan ~min ~max ~sat cs
+
+let take ?(rev= false) ?min ?max ?sat cs =
+  (if rev then snd else fst) @@ span ~rev ?min ?max ?sat cs
+
+let drop ?(rev= false) ?min ?max ?sat cs =
+  (if rev then fst else snd) @@ span ~rev ?min ?max ?sat cs
+
+let fcut ~sep:({ len= sep_len; _ } as sep)
+    ({ buffer= v; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cut: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - sep_len in
+  let rec check_sep i k =
+    if k > max_sep_zidx
+    then Some (buffer ~off:off ~len:i v,
+               buffer ~off:(off + i + sep_len) ~len:(len - i - sep_len) v)
+    else if get_char cs (i + k) = get_char sep k
+    then check_sep i (k + 1)
+    else scan (i + 1)
+  and scan i =
+    if i > max_s_zidx then None
+    else if get_char cs i = get_char sep 0
+    then check_sep i 1
+    else scan (i + 1) in
+  scan 0
+
+let rcut ~sep:({ len= sep_len; _ } as sep) ({ buffer= v; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cut: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - 1 in
+  let rec check_sep i k =
+    if k > max_sep_zidx then Some (buffer ~off:off ~len:i v,
+                                   buffer ~off:(off + i + sep_len) ~len:(len - i - sep_len) v)
+    else if get_char cs (i + k) = get_char sep k
+    then check_sep i (k + 1)
+    else rscan (i - 1)
+  and rscan i =
+    if i < 0 then None
+    else if get_char cs i = get_char sep 0
+    then check_sep i 1
+    else rscan (i - 1) in
+  rscan (max_s_zidx - max_sep_zidx)
+
+let cut ?(rev= false) ~sep cs = match rev with
+  | true  -> rcut ~sep cs
+  | false -> fcut ~sep cs
+
+let add_sub ~no_empty buf ~off ~len acc =
+  if len = 0
+  then ( if no_empty then acc else buffer ~off ~len buf :: acc )
+  else buffer ~off ~len buf :: acc
+
+let fcuts ~no_empty ~sep:({ len= sep_len; _ } as sep)
+      ({ buffer; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cuts: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - sep_len in
+  let rec check_sep zanchor i k acc =
+    if k > max_sep_zidx
+    then
+      let new_start = i + sep_len in
+      scan new_start new_start (add_sub ~no_empty buffer ~off:(off + zanchor) ~len:(i - zanchor) acc)
+    else
+      if get_char cs (i + k) = get_char sep k
+      then check_sep zanchor i (k + 1) acc
+      else scan zanchor (i + 1) acc
+  and scan zanchor i acc =
+    if i > max_s_zidx
+    then
+      if zanchor = 0 then (if no_empty && len = 0 then [] else [ cs ])
+      else List.rev (add_sub ~no_empty buffer ~off:(off + zanchor) ~len:(len - zanchor) acc)
+    else
+      if get_char cs i = get_char sep 0
+      then check_sep zanchor i 1 acc
+      else scan zanchor (i + 1) acc in
+  scan 0 0 []
+
+let rcuts ~no_empty ~sep:({ len= sep_len; _ } as sep)
+      ({ buffer; len; _ } as cs) =
+  if sep_len = 0 then invalid_arg "cuts: empty separator" ;
+  let s_len = len in
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - 1 in
+  let rec check_sep zanchor i k acc =
+    if k > max_sep_zidx
+    then let off = i + sep_len in
+         rscan i (i - sep_len) (add_sub ~no_empty buffer ~off ~len:(zanchor - off) acc)
+    else
+      if get_char cs (i + k) = get_char cs k
+      then check_sep zanchor i (k + 1) acc
+      else rscan zanchor (i - 1) acc
+  and rscan zanchor i acc =
+    if i < 0 then
+      if zanchor = s_len then ( if no_empty && s_len = 0 then [] else [ cs ])
+      else add_sub ~no_empty buffer ~off:0 ~len:zanchor acc
+    else
+      if get_char cs i = get_char sep 0
+      then check_sep zanchor i 1 acc
+      else rscan zanchor (i - 1) acc in
+  rscan s_len (max_s_zidx - max_sep_zidx) []
+
+let cuts ?(rev= false) ?(empty= true) ~sep cs = match rev with
+  | true  -> rcuts ~no_empty:(not empty) ~sep cs
+  | false -> fcuts ~no_empty:(not empty) ~sep cs
+
+let fields ?(empty= false) ?(is_sep= is_white) ({ buffer; off; len; } as cs) =
+  let no_empty = not empty in
+  let max_pos = len in
+  let rec loop i end_pos acc =
+    if i < 0 then begin
+        if end_pos = len
+        then ( if no_empty && len = 0 then [] else [ cs ])
+        else add_sub ~no_empty buffer ~off:off ~len:(end_pos - (i + 1)) acc
+      end else begin
+        if not (is_sep (get_char cs i))
+        then loop (i - 1) end_pos acc
+        else loop (i - 1) i (add_sub ~no_empty buffer ~off:(off + i + 1) ~len:(end_pos - (i + 1)) acc)
+      end in
+  loop (max_pos - 1) max_pos []
+
+let ffind sat ({ buffer= v; len; _ } as cs) =
+  let max_idx = len - 1 in
+  let rec loop i =
+    if i > max_idx then None
+    else if sat (get_char cs i)
+    then Some (buffer ~off:i ~len:1 v)
+    else loop (i + 1) in
+  loop 0
+
+let rfind sat ({ buffer= v; len; _ } as cs) =
+  let rec loop i =
+    if i < 0 then None
+    else if sat (get_char cs i)
+    then Some (buffer ~off:i ~len:1 v)
+    else loop (i - 1) in
+  loop (len - 1)
+
+let find ?(rev= false) sat cs = match rev with
+  | true  -> rfind sat cs
+  | false -> ffind sat cs
+
+let ffind_sub ~sub:({ len= sub_len; _ } as sub) ({ buffer= v; off; len; } as cs) =
+  if sub_len > len then None
+  else
+    let max_zidx_sub = sub_len - 1 in
+    let max_zidx_s = len - sub_len in
+    let rec loop i k =
+      if i > max_zidx_s then None
+      else if k > max_zidx_sub then Some (buffer v ~off:(off + i) ~len:sub_len)
+      else if k > 0
+      then ( if get_char sub k = get_char cs (i + k)
+             then loop i (k + 1)
+             else loop (i + 1) 0 )
+      else if get_char sub 0 = get_char cs i
+      then loop i 1
+      else loop (i + 1) 0 in
+    loop 0 0
+
+let rfind_sub ~sub:({ len= sub_len; _ } as sub) ({ buffer= v; len; _ } as cs) =
+  if sub_len > len then None
+  else
+    let max_zidx_sub = sub_len - 1 in
+    let rec loop i k =
+      if i < 0 then None
+      else if k > max_zidx_sub then Some (buffer v ~off:i ~len:sub_len)
+      else if k > 0
+      then ( if get_char sub k = get_char cs (i + k)
+             then loop i (k + 1)
+             else loop (i - 1) 0 )
+      else if get_char sub 0 = get_char cs i
+      then loop i 1
+      else loop (i - 1) 0 in
+    loop (len - sub_len) 0
+
+let find_sub ?(rev= false) ~sub cs = match rev with
+  | true  -> rfind_sub ~sub cs
+  | false -> ffind_sub ~sub cs
+
+let filter sat ({ len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = create len in
+    let max_zidx = len - 1 in
+    let rec loop b k i =
+      if i > max_zidx
+      then (if k = len then b else sub b 0 k)
+      else
+        let chr = get_char cs i in
+        if sat chr then ( set_char b k chr ; loop b (k + 1) (i + 1))
+        else loop b k (i + 1) in
+    loop b 0 0
+
+let filter_map f ({ len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = create len in
+    let max_zidx = len - 1 in
+    let rec loop b k i =
+      if i > max_zidx
+      then (if k = len then b else sub b 0 k)
+      else match f (get_char cs i) with
+           | Some chr ->
+              set_char b i chr ;
+              loop b (k + 1) (i + 1)
+           | None ->
+              loop b k (i + 1) in
+    loop b 0 0
+
+let map f ({ len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = create len in
+    for i = 0 to len - 1 do
+      set_char b i (f (get_char cs i))
+    done ; b
+
+let mapi f ({ len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = create len in
+    for i = 0 to len - 1 do
+      set_char b i (f i (get_char cs i))
+    done ; b

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -493,6 +493,286 @@ val rev: t -> t
 (** [rev t] is [t] in reverse order. The return value is a freshly allocated
     cstruct, and the argument is not modified. *)
 
+(** {1 Helpers to parse.}
+
+    [Cstruct] is used to manipulate {i payloads} which can be formatted
+   according an {{:https://perdu.com/}RFC} or an user-defined format. In such context, this module
+   provides utilities to be able to easily {i parse} {i payloads}.
+
+    Due to the type {!Cstruct.t}, no copy are done when you use these utilities
+   and you are able to extract your information without a big performance cost.
+
+    More precisely, each values returned by these utilities will be located into
+   the minor-heap where the base buffer will never be copied or relocated.
+
+    For instance, to parse a Git tree object:
+
+{v
+  entry := perm ' ' name '\000' 20byte
+  tree  := entry *
+v}
+
+    {[
+      open Cstruct
+
+      let ( >>= ) = Option.bind
+
+      let rec hash_of_name ~name payload =
+        if is_empty payload then raise Not_found
+        else
+          cut ~sep:(v " ") payload >>= fun (_, payload) ->
+          cut ~sep:(v "\000") payload >>= fun (name', payload) ->
+          if name = name' then with_range ~len:20 payload
+          else hash_of_name ~name (shift payload 20)
+    ]}
+
+    A [Cstruct] defines a possibly empty subsequence of bytes in a {e base}
+   buffer (a {!Bigarray.Array1.t}).
+
+    The positions of a buffer [b] of length [l] are the slits found
+   before each byte and after the last byte of the buffer. They are
+   labelled from left to right by increasing number in the range \[[0];[l]\].
+
+{v
+positions  0   1   2   3   4    l-1    l
+           +---+---+---+---+     +-----+
+  indices  | 0 | 1 | 2 | 3 | ... | l-1 |
+           +---+---+---+---+     +-----+
+v}
+
+    The [i]th byte index is between positions [i] and [i+1].
+
+    Formally we define a subbuffer of [b] as being a subsequence
+   of bytes defined by a {e off} position and a {e len} number. When
+   [len] is [0] the subbuffer is {e empty}. Note that for a given
+   base buffer there are as many empty subbuffers as there are positions
+   in the buffer.
+
+    Like in strings, we index the bytes of a subbuffer using zero-based
+   indices.
+*)
+
+val get : t -> int -> char
+(** [get cs zidx] is the byte of [cs] at its zero-based index [zidx].
+    It's an alias of {!get_char}.
+
+    @raise Invalid_argument if [zidx] is not an index of [cs]. *)
+
+val get_byte : t -> int -> int
+(** [get_byte cs zidx] is [Char.code (get cs zidx)]. It's an alias of {!get_uint8}. *)
+
+val string : ?off:int -> ?len:int -> string -> t
+(** [string ~off ~len str] is the subbuffer of [str] that starts at position [off]
+   (defaults to [0]) and stops at position [off + len] (defaults to
+   [String.length str]). [str] is fully-replaced by an fresh allocated
+   {!Cstruct.buffer}.
+
+    @raise Invalid_argument if [off] or [off + len] are not positions of [str].
+*)
+
+val buffer : ?off:int -> ?len:int -> buffer -> t
+(** [buffer ~off ~len buffer] is the sub-part of [buffer] that starts at
+   position [off] (default to [0]) and stops at position [off + len] (default to
+   [Bigarray.Array1.dim buffer]). [buffer] is used as the base buffer of the
+   returned value (no major-heap allocation are performed).
+
+    @raise Invalid_argument if [off] or [off + len] are not positions of
+   [buffer]. *)
+
+val start_pos : t -> int
+(** [start_pos cs] is [cs]'s start position in the base {!Cstruct.buffer}. *)
+
+val stop_pos : t -> int
+(** [stop_pos cs] is [cs]'s stop position in the base {!Cstruct.buffer}. *)
+
+val length : t -> int
+(** [length cs] is the number of bytes in [cs]. *)
+
+val head : ?rev:bool -> t -> char option
+(** [head cs] is [Some (get cs h)] with [h = 0] if [rev = false] (default) or [h
+   = length cs - 1] if [rev = true]. [None] is returned if [cs] is empty. *)
+
+val tail : ?rev:bool -> t -> t
+(** [tail cs] is [cs] without its first ([rev] is [false], default) or last
+   ([rev] is [true]) byte or [cs] is empty. *)
+
+val is_empty : t -> bool
+(** [is_empty cs] is [length cs = 0]. *)
+
+val is_prefix : affix:t -> t -> bool
+(** [is_prefix ~affix cs] is [true] iff [affix.[zidx] = cs.[zidx]] for all
+   indices [zidx] of [affix]. *)
+
+val is_suffix : affix:t -> t -> bool
+(** [is_suffix ~affix cs] is [true] iff [affix.[n - zidx] = cs.[m - zidx]] for
+   all indices [zidx] of [affix] with [n = length affix - 1] and [m = length cs
+   - 1]. *)
+
+val is_infix : affix:t -> t -> bool
+(** [is_infix ~affix cs] is [true] iff there exists an index [z] in [cs] such
+   that for all indices [zidx] of [affix] we have [affix.[zidx] = cs.[z +
+   zidx]]. *)
+
+val for_all : (char -> bool) -> t -> bool
+(** [for_all p cs] is [true] iff for all indices [zidx] of [cs], [p cs.[zidx] =
+   true]. *)
+
+val exists : (char -> bool) -> t -> bool
+(** [exists p cs] is [true] iff there exists an index [zidx] of [cs] with [p
+   cs.[zidx] = true]. *)
+
+val start : t -> t
+(** [start cs] is the empty sub-part at the start position of [cs]. *)
+
+val stop : t -> t
+(** [stop cs] is the empty sub-part at the stop position of [cs]. *)
+
+val trim : ?drop:(char -> bool) -> t -> t
+(** [trim ~drop cs] is [cs] with prefix and suffix bytes satisfying [drop] in
+   [cs] removed. [drop] defaults to [function ' ' | '\r' .. '\t' -> true | _ ->
+   false]. *)
+
+val span : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t * t
+(** [span ~rev ~min ~max ~sat cs] is [(l, r)] where:
+
+    {ul
+    {- if [rev] is [false] (default), [l] is at least [min] and at most
+       [max] consecutive [sat] satisfying initial bytes of [cs] or {!empty}
+       if there are no such bytes. [r] are the remaining bytes of [cs].}
+    {- if [rev] is [true], [r] is at least [min] and at most [max]
+       consecutive [sat] satisfying final bytes of [cs] or {!empty}
+       if there are no such bytes. [l] are the remaining bytes of [cs].}}
+
+    If [max] is unspecified the span is unlimited. If [min] is unspecified
+    it defaults to [0]. If [min > max] the condition can't be satisfied and
+    the left or right span, depending on [rev], is always empty. [sat]
+    defaults to [(fun _ -> true)].
+
+    The invariant [l ^ r = s] holds.
+
+    For instance, the {i ABNF} expression:
+
+{v
+  time := 1*10DIGIT
+v}
+
+    can be translated to:
+
+    {[
+      let (time, _) = span ~min:1 ~max:10 is_digit cs in
+    ]}
+
+    @raise Invalid_argument if [max] or [min] is negative. *)
+
+val take : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t
+(** [take ~rev ~min ~max ~sat cs] is the matching span of {!span} without the remaining one.
+    In other words:
+
+    {[(if rev then snd else fst) @@ span ~rev ~min ~max ~sat cs]} *)
+
+val drop : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t
+(** [drop ~rev ~min ~max ~sat cs] is the remaining span of {!span} without the matching one.
+    In other words:
+
+    {[(if rev then fst else snd) @@ span ~rev ~min ~max ~sat cs]} *)
+
+val cut : ?rev:bool -> sep:t -> t -> (t * t) option
+(** [cut ~sep cs] is either the pair [Some (l, r)] of the two
+    (possibly empty) sub-buffers of [cs] that are delimited by the first
+    match of the non empty separator string [sep] or [None] if [sep] can't
+    be matched in [cs]. Matching starts from the beginning of [cs] ([rev] is
+    [false], default) or the end ([rev] is [true]).
+
+    The invariant [l ^ sep ^ r = s] holds.
+
+    For instance, the {i ABNF} expression:
+
+{v
+  field_name := *PRINT
+  field_value := *ASCII
+  field := field_name ":" field_value
+v}
+
+    can be translated to:
+
+    {[
+      match cut ~sep:":" value with
+      | Some (field_name, field_value) -> ...
+      | None -> invalid_arg "invalid field"
+    ]}
+
+    @raise Invalid_argument if [sep] is the empty buffer. *)
+
+val cuts : ?rev:bool -> ?empty:bool -> sep:t -> t -> t list
+(** [cuts ~sep cs] is the list of all sub-buffers of [cs] that are
+    delimited by matches of the non empty separator [sep]. Empty sub-buffers are
+    omitted in the list if [empty] is [false] (default to [true]).
+
+    Matching separators in [cs] starts from the beginning of [cs]
+    ([rev] is [false], default) or the end ([rev] is [true]). Once
+    one is found, the separator is skipped and matching starts again,
+    that is separator matches can't overlap. If there is no separator
+    match in [cs], the list [[cs]] is returned.
+
+    The following invariants hold:
+    {ul
+    {- [concat ~sep (cuts ~empty:true ~sep cs) = cs]}
+    {- [cuts ~empty:true ~sep cs <> []]}}
+
+    For instance, the {i ABNF} expression:
+
+{v
+  arg := *(ASCII / ",") ; any characters exclude ","
+  args := arg *("," arg)
+v}
+
+    can be translated to:
+
+    {[
+      let args = cuts ~sep:"," buffer in
+    ]}
+
+    @raise Invalid_argument if [sep] is the empty buffer. *)
+
+val fields : ?empty:bool -> ?is_sep:(char -> bool) -> t -> t list
+(** [fields ~empty ~is_sep cs] is the list of (possibly empty)
+    sub-buffers that are delimited by bytes for which [is_sep] is
+    [true]. Empty sub-buffers are omitted in the list if [empty] is
+    [false] (defaults to [true]). [is_sep c] if it's not define by the
+    user is [true] iff [c] is an US-ASCII white space character,
+    that is one of space [' '] ([0x20]), tab ['\t'] ([0x09]), newline
+    ['\n'] ([0x0a]), vertical tab ([0x0b]), form feed ([0x0c]), carriage
+    return ['\r'] ([0x0d]). *)
+
+val find : ?rev:bool -> (char -> bool) -> t -> t option
+(** [find ~rev sat cs] is the sub-buffer of [cs] (if any) that spans
+    the first byte that satisfies [sat] in [cs] after position [start cs]
+    ([rev] is [false], default) or before [stop cs] ([rev] is [true]).
+    [None] is returned if there is no matching byte in [s]. *)
+
+val find_sub : ?rev:bool -> sub:t -> t -> t option
+(** [find_sub ~rev ~sub cs] is the sub-buffer of [cs] (if any) that spans
+    the first match of [sub] in [cs] after position [start cs]
+    ([rev] is [false], default) or before [stop cs] ([rev] is [true]).
+    Only bytes are compared and [sub] can be on a different base buffer.
+    [None] is returned if there is no match of [sub] in [s]. *)
+
+val filter : (char -> bool) -> t -> t
+(** [filter sat cs] is the buffer made of the bytes of [cs] that satisfy [sat],
+    in the same order. *)
+
+val filter_map : (char -> char option) -> t -> t
+(** [filter_map f cs] is the buffer made of the bytes of [cs] as mapped by
+    [f], in the same order. *)
+
+val map : (char -> char) -> t -> t
+(** [map f cs] is [cs'] with [cs'.[i] = f cs.[i]] for all indices [i]
+    of [cs]. [f] is invoked in increasing index order. *)
+
+val mapi : (int -> char -> char) -> t -> t
+(** [map f cs] is [cs'] with [cs'.[i] = f i cs.[i]] for all indices [i]
+    of [cs]. [f] is invoked in increasing index order. *)
+
 (**/**)
 val sum_lengths : caller:string -> t list -> int
 (** [sum_lengths ~caller acc l] is [acc] plus the sum of the lengths

--- a/lib/cstruct_parse.ml
+++ b/lib/cstruct_parse.ml
@@ -1,0 +1,392 @@
+(* (c) 2016 Daniel C. Bünzli
+   (c) 2020 Romain Calascibetta *)
+
+open Cstruct
+
+let empty = Cstruct.create 0
+
+external unsafe_blit_string_to_bigstring
+  : string -> int -> buffer -> int -> int -> unit
+  = "caml_blit_string_to_bigstring"
+[@@noalloc]
+
+let get { buffer; off; len; } zidx =
+  if zidx < 0 || zidx >= len then invalid_arg "index out of bounds" ;
+  Bigarray_compat.Array1.get buffer (off + zidx)
+
+let get_byte { buffer; off; len; } zidx =
+  if zidx < 0 || zidx >= len then invalid_arg "index out of bounds" ;
+  Char.code (Bigarray_compat.Array1.get buffer (off + zidx))
+
+let string ?(off= 0) ?len str =
+  let str_len = String.length str in
+  let len = match len with None -> str_len | Some len -> len in
+  if off < 0 || len < 0 || off + len > str_len then invalid_arg "index out of bounds" ;
+  let buffer = Bigarray_compat.(Array1.create char c_layout str_len) in
+  unsafe_blit_string_to_bigstring str 0 buffer 0 str_len ;
+  Cstruct.of_bigarray ~off ~len buffer
+
+let buffer ?(off= 0) ?len buffer =
+  let buffer_len = Bigarray_compat.Array1.dim buffer in
+  let len = match len with None -> buffer_len - off | Some len -> len in
+  if off < 0 || len < 0 || off + len > buffer_len then invalid_arg "index out of bounds" ;
+  Cstruct.of_bigarray ~off ~len buffer
+
+let length cs = Cstruct.len cs
+let start_pos { off; _ } = off
+let stop_pos { off; len; _ } = off + len
+
+let head ?(rev= false) ({ len; _ } as cs) =
+  if len = 0 then None
+  else Some (Cstruct.get_char cs (if rev then len - 1 else 0))
+
+let tail ?(rev= false) ({ buffer; off; len; } as cs) =
+  if len = 0 then cs
+  else if rev then Cstruct.of_bigarray ~off ~len:(len - 2) buffer
+  else Cstruct.of_bigarray ~off:(off + 1) ~len:(len - 1) buffer
+
+let is_empty { len; _ } = len = 0
+
+let is_prefix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx = alen - 1 in
+    let rec loop i =
+      if i > max_zidx then true
+      else if get_char affix i <> get_char cs i
+      then false else loop (succ i) in
+    loop 0
+
+let is_infix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx_a = alen - 1 in
+    let max_zidx_s = len - alen in
+    let rec loop i k =
+      if i > max_zidx_s then false
+      else if k > max_zidx_a then true
+      else if k > 0 then
+        if get_char affix k = get_char cs (i + k)
+        then loop i (succ k)
+        else loop (succ i) 0
+      else if get_char affix 0 = get_char cs i
+      then loop i 1
+      else loop (succ i) 0 in
+    loop 0 0
+
+let is_suffix ~affix:({ len= alen; _ } as affix)
+    ({ len; _ } as cs) =
+  if alen > len then false
+  else
+    let max_zidx = alen - 1 in
+    let max_zidx_a = alen - 1 in
+    let max_zidx_s = len - 1 in
+    let rec loop i =
+      if i > max_zidx then true
+      else if get_char affix (max_zidx_a - i) <> get_char cs (max_zidx_s - i)
+      then false else loop (succ i) in
+    loop 0
+
+let for_all sat cs =
+  let rec go acc i =
+    if i < len cs
+    then go (sat (get_char cs i) && acc) (succ i)
+    else acc in
+  go true 0
+
+let exists sat cs =
+  let rec go acc i =
+    if i < Cstruct.len cs
+    then go (sat (get_char cs i) || acc) (succ i)
+    else acc in
+  go false 0
+
+let start { buffer; off; _ } =
+  Cstruct.of_bigarray buffer ~off ~len:0
+
+let stop { buffer; off; len; } =
+  Cstruct.of_bigarray buffer ~off:(off + len) ~len:0
+
+let is_white = function ' ' | '\t' .. '\r' -> true | _ -> false
+
+let trim ?(drop = is_white) ({ buffer; off; len; } as cs) =
+  if len = 0 then cs
+  else
+    let max_zpos = len in
+    let max_zidx = len - 1 in
+    let rec left_pos i =
+      if i > max_zidx then max_zpos
+      else if drop (get_char cs i) then left_pos (succ i) else i in
+    let rec right_pos i =
+      if i < 0 then 0
+      else if drop (get_char cs i) then right_pos (pred i) else succ i in
+    let left = left_pos 0 in
+    if left = max_zpos
+    then Cstruct.of_bigarray buffer ~off:((off * 2 + len) / 2) ~len:0
+    else
+      let right = right_pos max_zidx in
+      if left = 0 && right = max_zpos then cs
+      else Cstruct.of_bigarray buffer ~off:(off + left) ~len:(right - left)
+
+let fspan ~min ~max ~sat ({ buffer= v; off; len; } as cs) =
+  if min < 0 then invalid_arg "span: negative min" ;
+  if max < 0 then invalid_arg "span: negative max" ;
+  if min > max || max = 0 then (buffer ~off:off ~len:0 v, cs)
+  else
+    let max_zidx = len - 1 in
+    let max_zidx =
+      let k = max - 1 in
+      if k > max_zidx || k < 0 then max_zidx else k in
+    let need_zidx = min in
+    let rec loop i =
+      if i <= max_zidx && sat (Cstruct.get_char cs i) then loop (i + 1)
+      else if i < need_zidx || i = 0 then buffer ~off:off ~len:0 v, cs
+      else if i = len then (cs, buffer ~off:(off + len) ~len:0 v)
+      else buffer ~off:off ~len:i v, buffer ~off:(off + i) ~len:(len - i) v in
+    loop 0
+
+let rspan ~min ~max ~sat ({ buffer= v; off; len; } as cs) =
+  if min < 0 then invalid_arg "span: negative min" ;
+  if max < 0 then invalid_arg "span: negative max" ;
+  if min > max || max = 0 then (cs, buffer ~off:(off + len) ~len:0 v)
+  else
+    let max_zidx = len - 1 in
+    let min_zidx =
+      let k = len - max in if k < 0 then 0 else k in
+    let need_zidx = len - min - 1 in
+    let rec loop i =
+      if i >= min_zidx && sat (Cstruct.get_char cs i) then loop (i - 1)
+      else if i > need_zidx || i = max_zidx then (cs, buffer ~off:(off + len) ~len:0 v)
+      else if i < 0 then (buffer ~off:off ~len:0 v, cs)
+      else (buffer ~off:off ~len:(i + 1) v, buffer ~off:(off + i + 1) ~len:(len - (i + 1)) v) in
+    loop max_zidx
+
+let span ?(rev= false) ?(min= 0) ?(max= max_int) ?(sat= fun _ -> true) cs =
+  match rev with
+  | true  -> rspan ~min ~max ~sat cs
+  | false -> fspan ~min ~max ~sat cs
+
+let take ?(rev= false) ?min ?max ?sat cs =
+  (if rev then snd else fst) @@ span ~rev ?min ?max ?sat cs
+
+let drop ?(rev= false) ?min ?max ?sat cs =
+  (if rev then fst else snd) @@ span ~rev ?min ?max ?sat cs
+
+let fcut ~sep:({ Cstruct.len= sep_len; _ } as sep)
+    ({ Cstruct.buffer= v; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cut: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - sep_len in
+  let rec check_sep i k =
+    if k > max_sep_zidx
+    then Some (buffer ~off:off ~len:i v,
+               buffer ~off:(off + i + sep_len) ~len:(len - i - sep_len) v)
+    else if Cstruct.get_char cs (i + k) = Cstruct.get_char sep k
+    then check_sep i (k + 1)
+    else scan (i + 1)
+  and scan i =
+    if i > max_s_zidx then None
+    else if Cstruct.get_char cs i = Cstruct.get_char sep 0
+    then check_sep i 1
+    else scan (i + 1) in
+  scan 0
+
+let rcut ~sep:({ Cstruct.len= sep_len; _ } as sep) ({ Cstruct.buffer= v; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cut: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - 1 in
+  let rec check_sep i k =
+    if k > max_sep_zidx then Some (buffer ~off:off ~len:i v,
+                                   buffer ~off:(off + i + sep_len) ~len:(len - i - sep_len) v)
+    else if Cstruct.get_char cs (i + k) = Cstruct.get_char sep k
+    then check_sep i (k + 1)
+    else rscan (i - 1)
+  and rscan i =
+    if i < 0 then None
+    else if Cstruct.get_char cs i = Cstruct.get_char sep 0
+    then check_sep i 1
+    else rscan (i - 1) in
+  rscan (max_s_zidx - max_sep_zidx)
+
+let cut ?(rev= false) ~sep cs = match rev with
+  | true  -> rcut ~sep cs
+  | false -> fcut ~sep cs
+
+let add_sub ~no_empty buf ~off ~len acc =
+  if len = 0
+  then ( if no_empty then acc else buffer ~off ~len buf :: acc )
+  else buffer ~off ~len buf :: acc
+
+let fcuts ~no_empty ~sep:({ Cstruct.len= sep_len; _ } as sep)
+      ({ Cstruct.buffer; off; len; } as cs) =
+  if sep_len = 0 then invalid_arg "cuts: empty separator" ;
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - sep_len in
+  let rec check_sep zanchor i k acc =
+    if k > max_sep_zidx
+    then
+      let new_start = i + sep_len in
+      scan new_start new_start (add_sub ~no_empty buffer ~off:(off + zanchor) ~len:(i - zanchor) acc)
+    else
+      if Cstruct.get_char cs (i + k) = Cstruct.get_char sep k
+      then check_sep zanchor i (k + 1) acc
+      else scan zanchor (i + 1) acc
+  and scan zanchor i acc =
+    if i > max_s_zidx
+    then
+      if zanchor = 0 then (if no_empty && len = 0 then [] else [ cs ])
+      else List.rev (add_sub ~no_empty buffer ~off:(off + zanchor) ~len:(len - zanchor) acc)
+    else
+      if Cstruct.get_char cs i = Cstruct.get_char sep 0
+      then check_sep zanchor i 1 acc
+      else scan zanchor (i + 1) acc in
+  scan 0 0 []
+
+let rcuts ~no_empty ~sep:({ Cstruct.len= sep_len; _ } as sep)
+      ({ Cstruct.buffer; len; _ } as cs) =
+  if sep_len = 0 then invalid_arg "cuts: empty separator" ;
+  let s_len = len in
+  let max_sep_zidx = sep_len - 1 in
+  let max_s_zidx = len - 1 in
+  let rec check_sep zanchor i k acc =
+    if k > max_sep_zidx
+    then let off = i + sep_len in
+         rscan i (i - sep_len) (add_sub ~no_empty buffer ~off ~len:(zanchor - off) acc)
+    else
+      if Cstruct.get_char cs (i + k) = Cstruct.get_char cs k
+      then check_sep zanchor i (k + 1) acc
+      else rscan zanchor (i - 1) acc
+  and rscan zanchor i acc =
+    if i < 0 then
+      if zanchor = s_len then ( if no_empty && s_len = 0 then [] else [ cs ])
+      else add_sub ~no_empty buffer ~off:0 ~len:zanchor acc
+    else
+      if Cstruct.get_char cs i = Cstruct.get_char sep 0
+      then check_sep zanchor i 1 acc
+      else rscan zanchor (i - 1) acc in
+  rscan s_len (max_s_zidx - max_sep_zidx) []
+
+let cuts ?(rev= false) ?(empty= true) ~sep cs = match rev with
+  | true  -> rcuts ~no_empty:(not empty) ~sep cs
+  | false -> fcuts ~no_empty:(not empty) ~sep cs
+
+let fields ?(empty= false) ?(is_sep= is_white) ({ Cstruct.buffer; off; len; } as cs) =
+  let no_empty = not empty in
+  let max_pos = len in
+  let rec loop i end_pos acc =
+    if i < 0 then begin
+        if end_pos = len
+        then ( if no_empty && len = 0 then [] else [ cs ])
+        else add_sub ~no_empty buffer ~off:off ~len:(end_pos - (i + 1)) acc
+      end else begin
+        if not (is_sep (Cstruct.get_char cs i))
+        then loop (i - 1) end_pos acc
+        else loop (i - 1) i (add_sub ~no_empty buffer ~off:(off + i + 1) ~len:(end_pos - (i + 1)) acc)
+      end in
+  loop (max_pos - 1) max_pos []
+
+let ffind sat ({ Cstruct.buffer= v; len; _ } as cs) =
+  let max_idx = len - 1 in
+  let rec loop i =
+    if i > max_idx then None
+    else if sat (Cstruct.get_char cs i)
+    then Some (buffer ~off:i ~len:1 v)
+    else loop (i + 1) in
+  loop 0
+
+let rfind sat ({ Cstruct.buffer= v; len; _ } as cs) =
+  let rec loop i =
+    if i < 0 then None
+    else if sat (Cstruct.get_char cs i)
+    then Some (buffer ~off:i ~len:1 v)
+    else loop (i - 1) in
+  loop (len - 1)
+
+let find ?(rev= false) sat cs = match rev with
+  | true  -> rfind sat cs
+  | false -> ffind sat cs
+
+let ffind_sub ~sub:({ Cstruct.len= sub_len; _ } as sub) ({ Cstruct.buffer= v; off; len; } as cs) =
+  if sub_len > len then None
+  else
+    let max_zidx_sub = sub_len - 1 in
+    let max_zidx_s = len - sub_len in
+    let rec loop i k =
+      if i > max_zidx_s then None
+      else if k > max_zidx_sub then Some (buffer v ~off:(off + i) ~len:sub_len)
+      else if k > 0
+      then ( if Cstruct.get_char sub k = Cstruct.get_char cs (i + k)
+             then loop i (k + 1)
+             else loop (i + 1) 0 )
+      else if Cstruct.get_char sub 0 = Cstruct.get_char cs i
+      then loop i 1
+      else loop (i + 1) 0 in
+    loop 0 0
+
+let rfind_sub ~sub:({ Cstruct.len= sub_len; _ } as sub) ({ Cstruct.buffer= v; len; _ } as cs) =
+  if sub_len > len then None
+  else
+    let max_zidx_sub = sub_len - 1 in
+    let rec loop i k =
+      if i < 0 then None
+      else if k > max_zidx_sub then Some (buffer v ~off:i ~len:sub_len)
+      else if k > 0
+      then ( if Cstruct.get_char sub k = Cstruct.get_char cs (i + k)
+             then loop i (k + 1)
+             else loop (i - 1) 0 )
+      else if Cstruct.get_char sub 0 = Cstruct.get_char cs i
+      then loop i 1
+      else loop (i - 1) 0 in
+    loop (len - sub_len) 0
+
+let find_sub ?(rev= false) ~sub cs = match rev with
+  | true  -> rfind_sub ~sub cs
+  | false -> ffind_sub ~sub cs
+
+let filter sat ({ Cstruct.len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = Cstruct.create len in
+    let max_zidx = len - 1 in
+    let rec loop b k i =
+      if i > max_zidx
+      then (if k = len then b else Cstruct.sub b 0 k)
+      else
+        let chr = Cstruct.get_char cs i in
+        if sat chr then ( Cstruct.set_char b k chr ; loop b (k + 1) (i + 1))
+        else loop b k (i + 1) in
+    loop b 0 0
+
+let filter_map f ({ Cstruct.len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = Cstruct.create len in
+    let max_zidx = len - 1 in
+    let rec loop b k i =
+      if i > max_zidx
+      then (if k = len then b else Cstruct.sub b 0 k)
+      else match f (Cstruct.get_char cs i) with
+           | Some chr ->
+              Cstruct.set_char b i chr ;
+              loop b (k + 1) (i + 1)
+           | None ->
+              loop b k (i + 1) in
+    loop b 0 0
+
+let map f ({ Cstruct.len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = Cstruct.create len in
+    for i = 0 to len - 1 do
+      Cstruct.set_char b i (f (Cstruct.get_char cs i))
+    done ; b
+
+let mapi f ({ Cstruct.len; _ } as cs) =
+  if len = 0 then empty
+  else
+    let b = Cstruct.create len in
+    for i = 0 to len - 1 do
+      Cstruct.set_char b i (f i (Cstruct.get_char cs i))
+    done ; b

--- a/lib/cstruct_parse.mli
+++ b/lib/cstruct_parse.mli
@@ -1,0 +1,283 @@
+(** {1 Helpers to parse.}
+
+    [Cstruct] is used to manipulate {i payloads} which can be formatted
+   according an {{:https://perdu.com/}RFC} or an user-defined format. In such context, this module
+   provides utilities to be able to easily {i parse} {i payloads}.
+
+    Due to the type {!Cstruct.t}, no copy are done when you use these utilities
+   and you are able to extract your information without a big performance cost.
+
+    More precisely, each values returned by these utilities will be located into
+   the minor-heap where the base buffer will never be copied or relocated.
+
+    For instance, to parse a Git tree object:
+
+{v
+  entry := perm ' ' name '\000' 20byte
+  tree  := entry *
+v}
+
+    {[
+      open Cstruct_parse
+
+      let ( >>= ) = Option.bind
+
+      let rec hash_of_name ~name payload =
+        if is_empty payload then raise Not_found
+        else
+          cut ~sep:(v " ") payload >>= fun (_, payload) ->
+          cut ~sep:(v "\000") payload >>= fun (name', payload) ->
+          if name = name' then with_range ~len:20 payload
+          else hash_of_name ~name (shift payload 20)
+    ]}
+
+    A [Cstruct] defines a possibly empty subsequence of bytes in a {e base}
+   buffer (a {!Bigarray.Array1.t}).
+
+    The positions of a buffer [b] of length [l] are the slits found
+   before each byte and after the last byte of the buffer. They are
+   labelled from left to right by increasing number in the range \[[0];[l]\].
+
+{v
+positions  0   1   2   3   4    l-1    l
+           +---+---+---+---+     +-----+
+  indices  | 0 | 1 | 2 | 3 | ... | l-1 |
+           +---+---+---+---+     +-----+
+v}
+
+    The [i]th byte index is between positions [i] and [i+1].
+
+    Formally we define a subbuffer of [b] as being a subsequence
+   of bytes defined by a {e off} position and a {e len} number. When
+   [len] is [0] the subbuffer is {e empty}. Note that for a given
+   base buffer there are as many empty subbuffers as there are positions
+   in the buffer.
+
+    Like in strings, we index the bytes of a subbuffer using zero-based
+   indices.
+*)
+
+open Cstruct
+
+val empty : t
+(** [empty] is the empty {!Cstruct.t}. *)
+
+val get : t -> int -> char
+(** [get cs zidx] is the byte of [cs] at its zero-based index [zidx].
+
+    @raise Invalid_argument if [zidx] is not an index of [cs]. *)
+
+val get_byte : t -> int -> int
+(** [get_byte cs zidx] is [Char.code (get cs zidx)]. *)
+
+val string : ?off:int -> ?len:int -> string -> t
+(** [string ~off ~len str] is the subbuffer of [str] that starts at position [off]
+   (defaults to [0]) and stops at position [off + len] (defaults to
+   [String.length str]). [str] is fully-replaced by an fresh allocated
+   {!Cstruct.buffer}.
+
+    @raise Invalid_argument if [off] or [off + len] are not positions of [str].
+   *)
+
+val buffer : ?off:int -> ?len:int -> buffer -> t
+(** [buffer ~off ~len buffer] is the sub-part of [buffer] that starts at
+   position [off] (default to [0]) and stops at position [off + len] (default to
+   [Bigarray.Array1.dim buffer]). [buffer] is used as the base buffer of the
+   returned value (no major-heap allocation are performed).
+
+    @raise Invalid_argument if [off] or [off + len] are not positions of
+   [buffer]. *)
+
+val start_pos : t -> int
+(** [start_pos cs] is [cs]'s start position in the base {!Cstruct.buffer}. *)
+
+val stop_pos : t -> int
+(** [stop_pos cs] is [cs]'s stop position in the base {!Cstruct.buffer}. *)
+
+val length : t -> int
+(** [length cs] is the number of bytes in [cs]. *)
+
+val head : ?rev:bool -> t -> char option
+(** [head cs] is [Some (get cs h)] with [h = 0] if [rev = false] (default) or [h
+   = length cs - 1] if [rev = true]. [None] is returned if [cs] is empty. *)
+
+val tail : ?rev:bool -> t -> t
+(** [tail cs] is [cs] without its first ([rev] is [false], default) or last
+   ([rev] is [true]) byte or [cs] is empty. *)
+
+val is_empty : t -> bool
+(** [is_empty cs] is [length cs = 0]. *)
+
+val is_prefix : affix:t -> t -> bool
+(** [is_prefix ~affix cs] is [true] iff [affix.[zidx] = cs.[zidx]] for all
+   indices [zidx] of [affix]. *)
+
+val is_suffix : affix:t -> t -> bool
+(** [is_suffix ~affix cs] is [true] iff [affix.[n - zidx] = cs.[m - zidx]] for
+   all indices [zidx] of [affix] with [n = length affix - 1] and [m = length cs
+   - 1]. *)
+
+val is_infix : affix:t -> t -> bool
+(** [is_infix ~affix cs] is [true] iff there exists an index [z] in [cs] such
+   that for all indices [zidx] of [affix] we have [affix.[zidx] = cs.[z +
+   zidx]]. *)
+
+val for_all : (char -> bool) -> t -> bool
+(** [for_all p cs] is [true] iff for all indices [zidx] of [cs], [p cs.[zidx] =
+   true]. *)
+
+val exists : (char -> bool) -> t -> bool
+(** [exists p cs] is [true] iff there exists an index [zidx] of [cs] with [p
+   cs.[zidx] = true]. *)
+
+val start : t -> t
+(** [start cs] is the empty sub-part at the start position of [cs]. *)
+
+val stop : t -> t
+(** [stop cs] is the empty sub-part at the stop position of [cs]. *)
+
+val trim : ?drop:(char -> bool) -> t -> t
+(** [trim ~drop cs] is [cs] with prefix and suffix bytes satisfying [drop] in
+   [cs] removed. [drop] defaults to [function ' ' | '\r' .. '\t' -> true | _ ->
+   false]. *)
+
+val span : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t * t
+(** [span ~rev ~min ~max ~sat cs] is [(l, r)] where:
+
+    {ul
+    {- if [rev] is [false] (default), [l] is at least [min] and at most
+       [max] consecutive [sat] satisfying initial bytes of [cs] or {!empty}
+       if there are no such bytes. [r] are the remaining bytes of [cs].}
+    {- if [rev] is [true], [r] is at least [min] and at most [max]
+       consecutive [sat] satisfying final bytes of [cs] or {!empty}
+       if there are no such bytes. [l] are the remaining bytes of [cs].}}
+
+    If [max] is unspecified the span is unlimited. If [min] is unspecified
+    it defaults to [0]. If [min > max] the condition can't be satisfied and
+    the left or right span, depending on [rev], is always empty. [sat]
+    defaults to [(fun _ -> true)].
+
+    The invariant [l ^ r = s] holds.
+
+    For instance, the {i ABNF} expression:
+
+{v
+  time := 1*10DIGIT
+v}
+
+    can be translated to:
+
+    {[
+      let (time, _) = span ~min:1 ~max:10 is_digit cs in
+    ]}
+
+    @raise Invalid_argument if [max] or [min] is negative. *)
+
+val take : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t
+(** [take ~rev ~min ~max ~sat cs] is the matching span of {!span} without the remaining one.
+    In other words:
+
+    {[(if rev then snd else fst) @@ span ~rev ~min ~max ~sat cs]} *)
+
+val drop : ?rev:bool -> ?min:int -> ?max:int -> ?sat:(char -> bool) -> t -> t
+(** [drop ~rev ~min ~max ~sat cs] is the remaining span of {!span} without the matching one.
+    In other words:
+
+    {[(if rev then fst else snd) @@ span ~rev ~min ~max ~sat cs]} *)
+
+val cut : ?rev:bool -> sep:t -> t -> (t * t) option
+(** [cut ~sep cs] is either the pair [Some (l, r)] of the two
+    (possibly empty) sub-buffers of [cs] that are delimited by the first
+    match of the non empty separator string [sep] or [None] if [sep] can't
+    be matched in [cs]. Matching starts from the beginning of [cs] ([rev] is
+    [false], default) or the end ([rev] is [true]).
+
+    The invariant [l ^ sep ^ r = s] holds.
+
+    For instance, the {i ABNF} expression:
+
+{v
+  field_name := *PRINT
+  field_value := *ASCII
+  field := field_name ":" field_value
+v}
+
+    can be translated to:
+
+    {[
+      match cut ~sep:":" value with
+      | Some (field_name, field_value) -> ...
+      | None -> invalid_arg "invalid field"
+    ]}
+
+    @raise Invalid_argument if [sep] is the empty buffer. *)
+
+val cuts : ?rev:bool -> ?empty:bool -> sep:t -> t -> t list
+(** [cuts ~sep cs] is the list of all sub-buffers of [cs] that are
+    delimited by matches of the non empty separator [sep]. Empty sub-buffers are
+    omitted in the list if [empty] is [false] (default to [true]).
+
+    Matching separators in [cs] starts from the beginning of [cs]
+    ([rev] is [false], default) or the end ([rev] is [true]). Once
+    one is found, the separator is skipped and matching starts again,
+    that is separator matches can't overlap. If there is no separator
+    match in [cs], the list [[cs]] is returned.
+
+    The following invariants hold:
+    {ul
+    {- [concat ~sep (cuts ~empty:true ~sep cs) = cs]}
+    {- [cuts ~empty:true ~sep cs <> []]}}
+
+    For instance, the {i ABNF} expression:
+
+{v
+  arg := *(ASCII / ",") ; any characters exclude ","
+  args := arg *("," arg)
+v}
+
+    can be translated to:
+
+    {[
+      let args = cuts ~sep:"," buffer in
+    ]}
+
+    @raise Invalid_argument if [sep] is the empty buffer. *)
+
+val fields : ?empty:bool -> ?is_sep:(char -> bool) -> t -> t list
+(** [fields ~empty ~is_sep cs] is the list of (possibly empty)
+    sub-buffers that are delimited by bytes for which [is_sep] is
+    [true]. Empty sub-buffers are omitted in the list if [empty] is
+    [false] (defaults to [true]). [is_sep c] if it's not define by the
+    user is [true] iff [c] is an US-ASCII white space character,
+    that is one of space [' '] ([0x20]), tab ['\t'] ([0x09]), newline
+    ['\n'] ([0x0a]), vertical tab ([0x0b]), form feed ([0x0c]), carriage
+    return ['\r'] ([0x0d]). *)
+
+val find : ?rev:bool -> (char -> bool) -> t -> t option
+(** [find ~rev sat cs] is the sub-buffer of [cs] (if any) that spans
+    the first byte that satisfies [sat] in [cs] after position [start cs]
+    ([rev] is [false], default) or before [stop cs] ([rev] is [true]).
+    [None] is returned if there is no matching byte in [s]. *)
+
+val find_sub : ?rev:bool -> sub:t -> t -> t option
+(** [find_sub ~rev ~sub cs] is the sub-buffer of [cs] (if any) that spans
+    the first match of [sub] in [cs] after position [start cs]
+    ([rev] is [false], default) or before [stop cs] ([rev] is [true]).
+    Only bytes are compared and [sub] can be on a different base buffer.
+    [None] is returned if there is no match of [sub] in [s]. *)
+
+val filter : (char -> bool) -> t -> t
+(** [filter sat cs] is the buffer made of the bytes of [cs] that satisfy [sat],
+    in the same order. *)
+
+val filter_map : (char -> char option) -> t -> t
+(** [filter_map f cs] is the buffer made of the bytes of [cs] as mapped by
+    [f], in the same order. *)
+
+val map : (char -> char) -> t -> t
+(** [map f cs] is [cs'] with [cs'.[i] = f cs.[i]] for all indices [i]
+    of [cs]. [f] is invoked in increasing index order. *)
+
+val mapi : (int -> char -> char) -> t -> t
+(** [map f cs] is [cs'] with [cs'.[i] = f i cs.[i]] for all indices [i]
+    of [cs]. [f] is invoked in increasing index order. *)

--- a/lib_test/dune
+++ b/lib_test/dune
@@ -1,9 +1,21 @@
 (executable
  (libraries cstruct bigarray alcotest cstruct-sexp)
+ (modules bounds tests)
  (name tests))
+
+(executable
+ (libraries cstruct alcotest)
+ (modules parse)
+ (name parse))
 
 (rule
  (alias runtest)
  (package cstruct-sexp)
  (action
   (run ./tests.exe -e)))
+
+(rule
+ (alias runtest)
+ (package cstruct)
+ (action
+  (run ./parse.exe -e)))

--- a/lib_test/parse.ml
+++ b/lib_test/parse.ml
@@ -1,0 +1,657 @@
+(* (c) 2016 Daniel C. Bünzli
+   (c) 2020 Romain Calascibetta *)
+
+open Cstruct
+
+let cstruct =
+  let pp ppf x = Format.fprintf ppf "%S" (Cstruct.to_string x) in
+  let equal a b = String.equal (Cstruct.to_string a) (Cstruct.to_string b) in
+  Alcotest.testable pp equal
+
+
+module Alcotest = struct
+  include Alcotest
+
+  let string = Alcotest.testable (Fmt.fmt "%S") String.equal
+end
+
+let misc =
+  Alcotest.test_case "misc" `Quick @@ fun () ->
+  Alcotest.(check cstruct) "empty" empty (Cstruct.create 0) ;
+  Alcotest.(check cstruct) "abc" (string "abc") (Cstruct.of_string "abc") ;
+  Alcotest.(check cstruct) "abc" (string ~off:0 ~len:1 "abc") (Cstruct.of_string "a") ;
+  Alcotest.(check cstruct) "abc" (string ~off:1 ~len:1 "abc") (Cstruct.of_string "b") ;
+  Alcotest.(check cstruct) "abc" (string ~off:1 ~len:2 "abc") (Cstruct.of_string "bc") ;
+  Alcotest.(check cstruct) "abc" (string ~off:2 ~len:1 "abc") (Cstruct.of_string "c") ;
+  Alcotest.(check cstruct) "abc" (string ~off:3 ~len:0 "abc") (Cstruct.create 0) ;
+  let sub = string ~off:2 ~len:1 "abc" in
+  Alcotest.(check int) "start_pos" (start_pos sub) 2 ;
+  Alcotest.(check int) "stop_pos"  (stop_pos sub)  3 ;
+  Alcotest.(check int) "length"    (length sub)    1 ;
+  let index_out_of_bounds = Invalid_argument "index out of bounds" in
+  Alcotest.check_raises "get" index_out_of_bounds @@ fun () -> ignore @@ get sub 3 ;
+  Alcotest.check_raises "get" index_out_of_bounds @@ fun () -> ignore @@ get sub 2 ;
+  Alcotest.check_raises "get" index_out_of_bounds @@ fun () -> ignore @@ get sub 1 ;
+  Alcotest.(check char) "get" (get sub 0) 'c' ;
+  Alcotest.(check int)  "get_byte" (get_byte sub 0) 0x63 ;
+;;
+
+let head =
+  Alcotest.test_case "head" `Quick @@ fun () ->
+  let { Cstruct.buffer= v; _ } = Cstruct.of_string "abc" in
+  let empty = buffer ~off:2 ~len:0 v in
+  let bc = buffer ~off:1 ~len:2 v in
+  Alcotest.(check (option char)) "empty" (head empty) None ;
+  Alcotest.(check (option char)) "empty" (head ~rev:true empty) None ;
+  Alcotest.(check (option char)) "bc" (head bc) (Some 'b') ;
+  Alcotest.(check (option char)) "bc" (head ~rev:true bc) (Some 'c') ;
+;;
+
+let start =
+  Alcotest.test_case "start" `Quick @@ fun () ->
+  let empty_pos cs pos =
+    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "start_pos" (start_pos cs) pos in
+  let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
+  empty_pos (start @@ string "") 0 ;
+  empty_pos (start @@ buffer ~off:0 ~len:0 abc) 0 ;
+  empty_pos (start @@ buffer ~off:0 ~len:1 abc) 0 ;
+  empty_pos (start @@ buffer ~off:0 ~len:2 abc) 0 ;
+  empty_pos (start @@ buffer ~off:0 ~len:3 abc) 0 ;
+  empty_pos (start @@ buffer ~off:1 ~len:0 abc) 1 ;
+  empty_pos (start @@ buffer ~off:1 ~len:1 abc) 1 ;
+  empty_pos (start @@ buffer ~off:1 ~len:2 abc) 1 ;
+  empty_pos (start @@ buffer ~off:2 ~len:0 abc) 2 ;
+  empty_pos (start @@ buffer ~off:2 ~len:1 abc) 2 ;
+  empty_pos (start @@ buffer ~off:3 ~len:0 abc) 3 ;
+;;
+
+let stop =
+  Alcotest.test_case "stop" `Quick @@ fun () ->
+  let empty_pos cs pos =
+    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "start_pos" (start_pos cs) pos in
+  let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
+  empty_pos (stop @@ string "") 0 ;
+  empty_pos (stop @@ buffer ~off:0 ~len:0 abc) 0 ;
+  empty_pos (stop @@ buffer ~off:0 ~len:1 abc) 1 ;
+  empty_pos (stop @@ buffer ~off:0 ~len:2 abc) 2 ;
+  empty_pos (stop @@ buffer ~off:0 ~len:3 abc) 3 ;
+  empty_pos (stop @@ buffer ~off:1 ~len:0 abc) 1 ;
+  empty_pos (stop @@ buffer ~off:1 ~len:1 abc) 2 ;
+  empty_pos (stop @@ buffer ~off:1 ~len:2 abc) 3 ;
+  empty_pos (stop @@ buffer ~off:2 ~len:0 abc) 2 ;
+  empty_pos (stop @@ buffer ~off:2 ~len:1 abc) 3 ;
+  empty_pos (stop @@ buffer ~off:3 ~len:0 abc) 3 ;
+;;
+
+let tail =
+  Alcotest.test_case "tail" `Quick @@ fun () ->
+  let empty_pos cs pos =
+    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "start_pos" (start_pos cs) pos in
+  let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
+  empty_pos (tail @@ string "") 0 ;
+  empty_pos (tail @@ buffer ~off:0 ~len:0 abc) 0 ;
+  empty_pos (tail @@ buffer ~off:0 ~len:1 abc) 1 ;
+  Alcotest.(check cstruct) "b" (tail @@ buffer ~off:0 ~len:2 abc) (string "b") ;
+  Alcotest.(check cstruct) "bc" (tail @@ buffer ~off:0 ~len:3 abc) (string "bc") ;
+  empty_pos (tail @@ buffer ~off:1 ~len:0 abc) 1 ;
+  empty_pos (tail @@ buffer ~off:1 ~len:1 abc) 2 ;
+  Alcotest.(check cstruct) "c" (tail @@ buffer ~off:1 ~len:2 abc) (string "c") ;
+  empty_pos (tail @@ buffer ~off:2 ~len:0 abc) 2 ;
+  empty_pos (tail @@ buffer ~off:2 ~len:1 abc) 3 ;
+  empty_pos (tail @@ buffer ~off:3 ~len:0 abc) 3 ;
+;;
+
+let is_empty =
+  Alcotest.test_case "is_empty" `Quick @@ fun () ->
+  Alcotest.(check bool) "empty" (is_empty (string "")) true ;
+  let { Cstruct.buffer= abcd; _ } = Cstruct.of_string "abcd" in
+  let { Cstruct.buffer= huyi; _ } = Cstruct.of_string "huyi" in
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:4 ~len:0 abcd)) true ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:0 ~len:0 huyi)) true ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:0 ~len:1 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:0 ~len:2 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:0 ~len:3 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:0 ~len:4 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:1 ~len:0 abcd)) true ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:1 ~len:1 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:1 ~len:2 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:1 ~len:3 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:2 ~len:0 abcd)) true ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:2 ~len:1 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:2 ~len:2 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:3 ~len:0 abcd)) true ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:3 ~len:1 huyi)) false ;
+  Alcotest.(check bool) "empty" (is_empty (buffer ~off:4 ~len:0 huyi)) true ;
+;;
+
+let is_prefix =
+  Alcotest.test_case "is_prefix" `Quick @@ fun () ->
+  let { Cstruct.buffer= ugoadfj; _ }      = Cstruct.of_string "ugoadf" in
+  let { Cstruct.buffer= dfkdjf; _ }       = Cstruct.of_string "dfkdjf" in
+  let { Cstruct.buffer= abhablablu; _ }   = Cstruct.of_string "abhablablu" in
+  let { Cstruct.buffer= hadfdffdf; _ }    = Cstruct.of_string "hadfdffdf" in
+  let { Cstruct.buffer= hadhabfdffdf; _ } = Cstruct.of_string "hadhabfdffdf" in
+  let { Cstruct.buffer= iabla; _ }        = Cstruct.of_string "iabla" in
+  let empty0 = buffer ~off:3 ~len:0 ugoadfj in
+  let empty1 = buffer ~off:4 ~len:0 dfkdjf in
+  let habla  = buffer ~off:2 ~len:5 abhablablu in
+  let h      = buffer ~off:0 ~len:1 hadfdffdf in
+  let ha     = buffer ~off:0 ~len:2 hadfdffdf in
+  let hab    = buffer ~off:3 ~len:3 hadhabfdffdf in
+  let abla   = buffer ~off:1 ~len:4 iabla in
+  Alcotest.(check cstruct) "empty" empty0 (Cstruct.of_string "") ;
+  Alcotest.(check cstruct) "empty" empty1 (Cstruct.of_string "") ;
+  Alcotest.(check cstruct) "habla" habla  (Cstruct.of_string "habla") ;
+  Alcotest.(check cstruct) "h"     h      (Cstruct.of_string "h") ;
+  Alcotest.(check cstruct) "ha"    ha     (Cstruct.of_string "ha") ;
+  Alcotest.(check cstruct) "hab"   hab    (Cstruct.of_string "hab") ;
+  Alcotest.(check cstruct) "abla"  abla   (Cstruct.of_string "abla") ;
+  Alcotest.(check bool) "is_prefix empty0 empty0" (is_prefix ~affix:empty0 empty1) true ;
+  Alcotest.(check bool) "is_prefix empty0 habla"  (is_prefix ~affix:empty0 habla)  true ;
+  Alcotest.(check bool) "is_prefix ha empty1"     (is_prefix ~affix:ha     empty1) false ;
+  Alcotest.(check bool) "is_prefix ha h"          (is_prefix ~affix:ha     h)      false ;
+  Alcotest.(check bool) "is_prefix ha ha"         (is_prefix ~affix:ha     ha)     true ;
+  Alcotest.(check bool) "is_prefix ha hab"        (is_prefix ~affix:ha     hab)    true ;
+  Alcotest.(check bool) "is_prefix ha habla"      (is_prefix ~affix:ha     habla)  true ;
+  Alcotest.(check bool) "is_prefix ha abla"       (is_prefix ~affix:ha     abla)   false ;
+;;
+
+let is_infix =
+  Alcotest.test_case "is_infix" `Quick @@ fun () ->
+  let { Cstruct.buffer= ugoadfj; _ }      = Cstruct.of_string "ugoadfj" in
+  let { Cstruct.buffer= dfkdjf; _ }       = Cstruct.of_string "dfkdjf" in
+  let { Cstruct.buffer= aasdflablu; _ }   = Cstruct.of_string "aasdflablu" in
+  let { Cstruct.buffer= cda; _ }          = Cstruct.of_string "cda" in
+  let { Cstruct.buffer= h; _ }            = Cstruct.of_string "h" in
+  let { Cstruct.buffer= uhadfdffdf; _ }   = Cstruct.of_string "uhadfdffdf" in
+  let { Cstruct.buffer= ah; _ }           = Cstruct.of_string "ah" in
+  let { Cstruct.buffer= aaaha; _ }        = Cstruct.of_string "aaaha" in
+  let { Cstruct.buffer= ahaha; _ }        = Cstruct.of_string "ahaha" in
+  let { Cstruct.buffer= hahbdfdf; _ }     = Cstruct.of_string "hahbdfdf" in
+  let { Cstruct.buffer= blhahbdfdf; _ }   = Cstruct.of_string "blhahbdfdf" in
+  let { Cstruct.buffer= fblhahbdfdfl; _ } = Cstruct.of_string "fblhahbdfdfl" in
+  let empty0 = buffer ~off:1 ~len:0 ugoadfj in
+  let empty1 = buffer ~off:2 ~len:0 dfkdjf in
+  let asdf   = buffer ~off:1 ~len:4 aasdflablu in
+  let a      = buffer ~off:2 ~len:1 cda in
+  let h      = buffer ~off:0 ~len:1 h in
+  let ha     = buffer ~off:1 ~len:2 uhadfdffdf in
+  let ah     = buffer ~off:0 ~len:2 ah in
+  let aha    = buffer ~off:2 ~len:3 aaaha in
+  let haha   = buffer ~off:1 ~len:4 ahaha in
+  let hahb   = buffer ~off:0 ~len:4 hahbdfdf in
+  let blhahb = buffer ~off:0 ~len:6 blhahbdfdf in
+  let blha   = buffer ~off:1 ~len:4 fblhahbdfdfl in
+  let blh    = buffer ~off:1 ~len:3 fblhahbdfdfl in
+  Alcotest.(check cstruct) "asdf"   asdf   (Cstruct.of_string "asdf") ;
+  Alcotest.(check cstruct) "ha"     ha     (Cstruct.of_string "ha") ;
+  Alcotest.(check cstruct) "h"      h      (Cstruct.of_string "h") ;
+  Alcotest.(check cstruct) "a"      a      (Cstruct.of_string "a") ;
+  Alcotest.(check cstruct) "aha"    aha    (Cstruct.of_string "aha") ;
+  Alcotest.(check cstruct) "haha"   haha   (Cstruct.of_string "haha") ;
+  Alcotest.(check cstruct) "hahb"   hahb   (Cstruct.of_string "hahb") ;
+  Alcotest.(check cstruct) "blhahb" blhahb (Cstruct.of_string "blhahb") ;
+  Alcotest.(check cstruct) "blha"   blha   (Cstruct.of_string "blha") ;
+  Alcotest.(check cstruct) "blh"    blh    (Cstruct.of_string "blh") ;
+  Alcotest.(check bool) "is_infix empty0 empty1" (is_infix ~affix:empty0 empty1) true ;
+  Alcotest.(check bool) "is_infix empty0 asdf"   (is_infix ~affix:empty0 asdf)   true ;
+  Alcotest.(check bool) "is_infix empty0 ha"     (is_infix ~affix:empty0 ha)     true ;
+  Alcotest.(check bool) "is_infix ha empty1"     (is_infix ~affix:ha     empty1) false ;
+  Alcotest.(check bool) "is_infix ha a"          (is_infix ~affix:ha     a)      false ;
+  Alcotest.(check bool) "is_infix ha h"          (is_infix ~affix:ha     h)      false ;
+  Alcotest.(check bool) "is_infix ha ah"         (is_infix ~affix:ha     ah)     false ;
+  Alcotest.(check bool) "is_infix ha ha"         (is_infix ~affix:ha     ha)     true ;
+  Alcotest.(check bool) "is_infix ha aha"        (is_infix ~affix:ha     aha)    true ;
+  Alcotest.(check bool) "is_infix ha haha"       (is_infix ~affix:ha     haha)   true ;
+  Alcotest.(check bool) "is_infix ha hahb"       (is_infix ~affix:ha     hahb)   true ;
+  Alcotest.(check bool) "is_infix ha blhahb"     (is_infix ~affix:ha     blhahb) true ;
+  Alcotest.(check bool) "is_infix ha blha"       (is_infix ~affix:ha     blha)   true ;
+  Alcotest.(check bool) "is_infix ha blh"        (is_infix ~affix:ha     blh)    false ;
+;;
+
+let is_suffix =
+  Alcotest.test_case "is_suffix" `Quick @@ fun () ->
+  let { Cstruct.buffer= ugoadfj; _ }    = Cstruct.of_string "ugoadfj" in
+  let { Cstruct.buffer= dfkdjf; _ }     = Cstruct.of_string "dfkdjf" in
+  let { Cstruct.buffer= aasdflablu; _ } = Cstruct.of_string "aasdflablu" in
+  let { Cstruct.buffer= cda; _ }        = Cstruct.of_string "cda" in
+  let { Cstruct.buffer= h; _ }          = Cstruct.of_string "h" in
+  let { Cstruct.buffer= uhadfdffdf; _ } = Cstruct.of_string "uhadfdffdf" in
+  let { Cstruct.buffer= ah; _ }         = Cstruct.of_string "ah" in
+  let { Cstruct.buffer= aaaha; _ }      = Cstruct.of_string "aaaha" in
+  let { Cstruct.buffer= ahaha; _ }      = Cstruct.of_string "ahaha" in
+  let { Cstruct.buffer= hahbdfdf; _ }   = Cstruct.of_string "hahbdfdf" in
+  let empty0 = buffer ~off:1 ~len:0 ugoadfj in
+  let empty1 = buffer ~off:2 ~len:0 dfkdjf in
+  let asdf   = buffer ~off:1 ~len:4 aasdflablu in
+  let a      = buffer ~off:2 ~len:1 cda in
+  let h      = buffer ~off:0 ~len:1 h in
+  let ha     = buffer ~off:1 ~len:2 uhadfdffdf in
+  let ah     = buffer ~off:0 ~len:2 ah in
+  let aha    = buffer ~off:2 ~len:3 aaaha in
+  let haha   = buffer ~off:1 ~len:4 ahaha in
+  let hahb   = buffer ~off:0 ~len:4 hahbdfdf in
+  Alcotest.(check cstruct) "asdf"   asdf   (Cstruct.of_string "asdf") ;
+  Alcotest.(check cstruct) "ha"     ha     (Cstruct.of_string "ha") ;
+  Alcotest.(check cstruct) "h"      h      (Cstruct.of_string "h") ;
+  Alcotest.(check cstruct) "a"      a      (Cstruct.of_string "a") ;
+  Alcotest.(check cstruct) "aha"    aha    (Cstruct.of_string "aha") ;
+  Alcotest.(check cstruct) "haha"   haha   (Cstruct.of_string "haha") ;
+  Alcotest.(check cstruct) "hahb"   hahb   (Cstruct.of_string "hahb") ;
+  Alcotest.(check bool) "is_suffix empty0 empty1" (is_suffix ~affix:empty0 empty1)     true ;
+  Alcotest.(check bool) "is_suffix empty0 asdf"   (is_suffix ~affix:empty0 asdf)       true ;
+  Alcotest.(check bool) "is_suffix ha empty1"     (is_suffix ~affix:ha     empty1)     false ;
+  Alcotest.(check bool) "is_suffix ha a"          (is_suffix ~affix:ha     a)          false ;
+  Alcotest.(check bool) "is_suffix ha h"          (is_suffix ~affix:ha     h)          false ;
+  Alcotest.(check bool) "is_suffix ha ah"         (is_suffix ~affix:ha     ah)         false ;
+  Alcotest.(check bool) "is_suffix ha ha"         (is_suffix ~affix:ha     ha)         true ;
+  Alcotest.(check bool) "is_suffix ha aha"        (is_suffix ~affix:ha     aha)        true ;
+  Alcotest.(check bool) "is_suffix ha haha"       (is_suffix ~affix:ha     haha)       true ;
+  Alcotest.(check bool) "is_suffix ha hahb"       (is_suffix ~affix:ha     hahb)       false ;
+;;
+
+let () = Printexc.record_backtrace true
+
+let for_all =
+  Alcotest.test_case "for_all" `Quick @@ fun () ->
+  let { Cstruct.buffer= asldfksaf; _ } = Cstruct.of_string "asldfksaf" in
+  let { Cstruct.buffer= sf123df; _ } = Cstruct.of_string "sf123df" in
+  let { Cstruct.buffer= _412; _ } = Cstruct.of_string "412" in
+  let { Cstruct.buffer= aaa142; _ } = Cstruct.of_string "aaa142" in
+  let { Cstruct.buffer= aad124; _ } = Cstruct.of_string "aad124" in
+  let empty = buffer ~off:3 ~len:0 asldfksaf in
+  let s123  = buffer ~off:2 ~len:3 sf123df in
+  let s412  = buffer _412 in
+  let s142  = buffer ~off:3 aaa142 in
+  let s124  = buffer ~off:3 aad124 in
+  Alcotest.(check cstruct) "empty" empty (Cstruct.of_string "") ;
+  Alcotest.(check cstruct) "123"   s123 (Cstruct.of_string "123") ;
+  Alcotest.(check cstruct) "412"   s412 (Cstruct.of_string "412") ;
+  Alcotest.(check cstruct) "142"   s142 (Cstruct.of_string "142") ;
+  Alcotest.(check cstruct) "124"   s124 (Cstruct.of_string "124") ;
+  Alcotest.(check bool) "for_all" (for_all (fun _ -> false) empty) true ;
+  Alcotest.(check bool) "for_all" (for_all (fun _ -> true)  empty) true ;
+  Alcotest.(check bool) "for_all" (for_all (fun c -> Char.code c < 0x34) s123) true ;
+  Alcotest.(check bool) "for_all" (for_all (fun c -> Char.code c < 0x34) s412) false ;
+  Alcotest.(check bool) "for_all" (for_all (fun c -> Char.code c < 0x34) s142) false ;
+  Alcotest.(check bool) "for_all" (for_all (fun c -> Char.code c < 0x34) s124) false ;
+;;
+
+let exists =
+  Alcotest.test_case "exists" `Quick @@ fun () ->
+  let { Cstruct.buffer= asldfksaf; _ } = Cstruct.of_string "asldfksaf" in
+  let { Cstruct.buffer= a541; _ } = Cstruct.of_string "a541" in
+  let { Cstruct.buffer= a154; _ } = Cstruct.of_string "a154" in
+  let { Cstruct.buffer= _654adf; _ } = Cstruct.of_string "654adf" in
+  let empty = buffer ~off:3 ~len:0 asldfksaf in
+  let s541  = buffer ~off:1 ~len:3 a541 in
+  let s154  = buffer ~off:1 a154 in
+  let s654  = buffer ~len:3 _654adf in
+  Alcotest.(check cstruct) "empty" empty (Cstruct.of_string "") ;
+  Alcotest.(check cstruct) "541"   s541  (Cstruct.of_string "541") ;
+  Alcotest.(check cstruct) "154"   s154  (Cstruct.of_string "154") ;
+  Alcotest.(check cstruct) "654"   s654  (Cstruct.of_string "654") ;
+  Alcotest.(check bool) "exists" (exists (fun _ -> false) empty) false ;
+  Alcotest.(check bool) "exists" (exists (fun _ -> true)  empty) false ;
+  Alcotest.(check bool) "exists" (exists (fun c -> Char.code c < 0x34) s541) true ;
+  Alcotest.(check bool) "exists" (exists (fun c -> Char.code c < 0x34) s154) true ;
+  Alcotest.(check bool) "exists" (exists (fun c -> Char.code c < 0x34) s654) false ;
+;;
+
+let trim =
+  Alcotest.test_case "trim" `Quick @@ fun () ->
+  let drop_a c = c = 'a' in
+  let { Cstruct.buffer= base; _ } = Cstruct.of_string "00aaaabcdaaaa00" in
+  let aaaabcdaaaa = buffer ~off:2 ~len:11 base in
+  let aaaabcd = buffer ~off:2 ~len:7 base in
+  let bcdaaaa = buffer ~off:6 ~len:7 base in
+  let aaaa = buffer ~off:2 ~len:4 base in
+  Alcotest.(check cstruct) "trim" (trim (string "\t abcd \t")) (Cstruct.of_string "abcd") ;
+  Alcotest.(check cstruct) "trim" (trim aaaabcdaaaa) (Cstruct.of_string "aaaabcdaaaa") ;
+  Alcotest.(check cstruct) "trim" (trim ~drop:drop_a aaaabcdaaaa) (Cstruct.of_string "bcd") ;
+  Alcotest.(check cstruct) "trim" (trim ~drop:drop_a aaaabcd) (Cstruct.of_string "bcd") ;
+  Alcotest.(check cstruct) "trim" (trim ~drop:drop_a bcdaaaa) (Cstruct.of_string "bcd") ;
+  let empty_pos cs pos =
+    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "start_pos" (start_pos cs) pos in
+  empty_pos (trim ~drop:drop_a aaaa) 4 ;
+  empty_pos (trim (string "    ")) 2 ;
+;;
+
+let span =
+  Alcotest.test_case "span" `Quick @@ fun () ->
+  (* XXX(dinosaure): clash of names between [start] and [Cstruct.start]. *)
+  let open Cstruct in
+  let test ?(rev= false) ?min ?max ?sat cs (cl, cr as expect) =
+    let res = span ~rev ?min ?max ?sat cs in
+    let t = take ~rev ?min ?max ?sat cs in
+    let d = drop ~rev ?min ?max ?sat cs in
+    Alcotest.(check (pair cstruct cstruct)) "span" res expect ;
+    Alcotest.(check cstruct) "take" t (if rev then cr else cl) ;
+    Alcotest.(check cstruct) "drop" d (if rev then cl else cr) in
+  let invalid ?rev ?min ?max ?sat cs =
+    Alcotest.check_raises "invalid" (Invalid_argument "span")
+      (fun () -> try ignore @@ span ?rev ?min ?max ?sat cs
+            with Invalid_argument _ -> invalid_arg "span") in
+  let is_white = function ' ' | '\t' .. '\r' -> true | _ -> false in
+  let is_letter = function 'A' .. 'Z' | 'a' .. 'z' -> true | _ -> false in
+  let { Cstruct.buffer= base; _ } = Cstruct.of_string "0ab cd0" in
+  let empty = buffer ~off:3 ~len:0 base in
+  let ab_cd = buffer ~off:1 ~len:5 base in
+  let ab    = buffer ~off:1 ~len:2 base in
+  let _cd   = buffer ~off:3 ~len:3 base in
+  let cd    = buffer ~off:4 ~len:2 base in
+  let ab_   = buffer ~off:1 ~len:3 base in
+  let a     = buffer ~off:1 ~len:1 base in
+  let b_cd  = buffer ~off:2 ~len:4 base in
+  let b     = buffer ~off:2 ~len:1  base in
+  let d     = buffer ~off:5 ~len:1 base in
+  let ab_c  = buffer ~off:1 ~len:4 base in
+  test ~rev:false ~min:1 ~max:0 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~min:1 ~max:0 ab_cd (ab_cd, stop ab_cd) ;
+  test ~sat:is_white  ab_cd (start ab_cd, ab_cd) ;
+  test ~sat:is_letter ab_cd (ab, _cd) ;
+  test ~max:1 ~sat:is_letter ab_cd (a, b_cd) ;
+  test ~max:0 ~sat:is_letter ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~sat:is_white ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:true  ~sat:is_letter ab_cd (ab_, cd) ;
+  test ~rev:true  ~max:1 ~sat:is_letter ab_cd (ab_c, d) ;
+  test ~rev:true  ~max:0 ~sat:is_letter ab_cd (ab_cd, stop ab_cd) ;
+  test ~sat:is_letter ab (ab, stop ab) ;
+  test ~max:1 ~sat:is_letter ab (a, b) ;
+  test ~sat:is_letter b (b, empty) ;
+  test ~rev:true  ~max:1 ~sat:is_letter ab (a, b) ;
+  test ~max:1 ~sat:is_white ab (start ab, ab) ;
+  test ~rev:true  ~sat:is_white empty (empty, empty) ;
+  test ~sat:is_white empty (empty, empty) ;
+  (* TODO: invalid *)
+  invalid ~rev:false ~min:(-1) empty ;
+  invalid ~rev:true  ~min:(-1) empty ;
+  invalid ~rev:false ~max:(-1) empty ;
+  invalid ~rev:true  ~max:(-1) empty ;
+  test ~rev:false empty (empty, empty) ;
+  test ~rev:true  empty (empty, empty) ;
+  test ~rev:false ~min:0 ~max:0 empty (empty, empty) ;
+  test ~rev:true  ~min:0 ~max:0 empty (empty, empty) ;
+  test ~rev:false ~min:1 ~max:0 empty (empty, empty) ;
+  test ~rev:true  ~min:1 ~max:0 empty (empty, empty) ;
+  test ~rev:false ~max:0 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~max:0 ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:false ~max:2 ab_cd (ab, _cd) ;
+  test ~rev:true  ~max:2 ab_cd (ab_, cd) ;
+  test ~rev:false ~min:6 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~min:6 ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:false ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:true  ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:false ~max:30 ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:true  ~max:30 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:false ~sat:is_white ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~sat:is_white ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:false ~sat:is_letter ab_cd (ab, _cd) ;
+  test ~rev:true  ~sat:is_letter ab_cd (ab_, cd) ;
+  test ~rev:false ~sat:is_letter ~max:0 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~sat:is_letter ~max:0 ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:false ~sat:is_letter ~max:1 ab_cd (a, b_cd) ;
+  test ~rev:true  ~sat:is_letter ~max:1 ab_cd (ab_c, d) ;
+  test ~rev:false ~sat:is_letter ~min:2 ~max:1 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~sat:is_letter ~min:2 ~max:1 ab_cd (ab_cd, stop ab_cd) ;
+  test ~rev:false ~sat:is_letter ~min:3 ab_cd (start ab_cd, ab_cd) ;
+  test ~rev:true  ~sat:is_letter ~min:3 ab_cd (ab_cd, stop ab_cd) ;
+;;
+
+let cut =
+  Alcotest.test_case "cut" `Quick @@ fun () ->
+  let s str = string ~off:1 ~len:(String.length str) (Fmt.strf "\x00%s\x00" str) in
+  let cut ?rev ~sep str = cut ?rev ~sep:(s sep) (s str) in
+  let invalid_cut_argument = Invalid_argument "cut: empty separator" in
+  Alcotest.check_raises "invalid" invalid_cut_argument
+    (fun () -> ignore (cut ~sep:"" "")) ;
+  Alcotest.check_raises "invalid" invalid_cut_argument
+    (fun () -> ignore (cut ~sep:"" "123")) ;
+  let opc = Alcotest.(option (pair cstruct cstruct)) in
+  Alcotest.(check opc) "0" (cut ~sep:"," "") None ;
+  Alcotest.(check opc) "1" (cut ~sep:"," ",") (Some (string "", string "")) ;
+  Alcotest.(check opc) "2" (cut ~sep:"," ",,") (Some (string "", string ",")) ;
+  Alcotest.(check opc) "3" (cut ~sep:"," ",,,") (Some (string "", string ",,")) ;
+  Alcotest.(check opc) "4" (cut ~sep:"," "123") None ;
+  Alcotest.(check opc) "5" (cut ~sep:"," ",123") (Some (string "", string "123")) ;
+  Alcotest.(check opc) "6" (cut ~sep:"," "123,") (Some (string "123", string "")) ;
+  Alcotest.(check opc) "7" (cut ~sep:"," "1,2,3") (Some (string "1", string "2,3")) ;
+  Alcotest.(check opc) "8" (cut ~sep:"," " 1,2,3") (Some (string " 1", string "2,3")) ;
+  Alcotest.(check opc) "9" (cut ~sep:"<>" "") None ;
+  Alcotest.(check opc) "10" (cut ~sep:"<>" "<>") (Some (string "", string "")) ;
+  Alcotest.(check opc) "11" (cut ~sep:"<>" "<><>") (Some (string "", string "<>")) ;
+  Alcotest.(check opc) "12" (cut ~sep:"<>" "<><><>") (Some (string "", string "<><>")) ;
+  Alcotest.(check opc) "13" (cut ~rev:true ~sep:"<>" "1") None ;
+  Alcotest.(check opc) "14" (cut ~sep:"<>" "123") None ;
+  Alcotest.(check opc) "15" (cut ~sep:"<>" "<>123") (Some (string "", string "123")) ;
+  Alcotest.(check opc) "16" (cut ~sep:"<>" "123<>") (Some (string "123", string "")) ;
+  Alcotest.(check opc) "17" (cut ~sep:"<>" "1<>2<>3") (Some (string "1", string "2<>3")) ;
+  Alcotest.(check opc) "18" (cut ~sep:"<>" ">>><>>>><>>>><>>>>") (Some (string ">>>", string ">>><>>>><>>>>")) ;
+  Alcotest.(check opc) "19" (cut ~sep:"<->" "<->>->") (Some (string "", string ">->")) ;
+  Alcotest.(check opc) "20" (cut ~rev:true ~sep:"<->" "<-") None ;
+  Alcotest.(check opc) "21" (cut ~sep:"aa" "aa") (Some (string "", string "")) ;
+  Alcotest.(check opc) "22" (cut ~sep:"aa" "aaa") (Some (string "", string "a")) ;
+  Alcotest.(check opc) "23" (cut ~sep:"aa" "aaaa") (Some (string "", string "aa")) ;
+  Alcotest.(check opc) "24" (cut ~sep:"aa" "aaaaa") (Some (string "", string "aaa")) ;
+  Alcotest.(check opc) "25" (cut ~sep:"aa" "aaaaaa") (Some (string "", string "aaaa")) ;
+  Alcotest.(check opc) "26" (cut ~sep:"ab" "faaaa") None ;
+  let rev = true in
+  Alcotest.check_raises "invalid" invalid_cut_argument
+    (fun () -> ignore (cut ~rev ~sep:"" "")) ;
+  Alcotest.check_raises "invalid" invalid_cut_argument
+    (fun () -> ignore (cut ~rev ~sep:"" "123")) ;
+  Alcotest.(check opc) "27" (cut ~rev ~sep:"," "") None ;
+  Alcotest.(check opc) "28" (cut ~rev ~sep:"," ",") (Some (string "", string "")) ;
+  Alcotest.(check opc) "29" (cut ~rev ~sep:"," ",,") (Some (string ",", string "")) ;
+  Alcotest.(check opc) "30" (cut ~rev ~sep:"," ",,,") (Some (string ",,", string "")) ;
+  Alcotest.(check opc) "31" (cut ~rev ~sep:"," "123") None ;
+  Alcotest.(check opc) "32" (cut ~rev ~sep:"," ",123") (Some (string "", string "123")) ;
+  Alcotest.(check opc) "33" (cut ~rev ~sep:"," "123,") (Some (string "123", string "")) ;
+  Alcotest.(check opc) "34" (cut ~rev ~sep:"," "1,2,3") (Some (string "1,2", string "3")) ;
+  Alcotest.(check opc) "35" (cut ~rev ~sep:"," "1,2,3 ") (Some (string "1,2", string "3 ")) ;
+  Alcotest.(check opc) "36" (cut ~rev ~sep:"<>" "") None ;
+  Alcotest.(check opc) "37" (cut ~rev ~sep:"<>" "<>") (Some (string "", string "")) ;
+  Alcotest.(check opc) "38" (cut ~rev ~sep:"<>" "<><>") (Some (string "<>", string "")) ;
+  Alcotest.(check opc) "39" (cut ~rev ~sep:"<>" "<><><>") (Some (string "<><>", string "")) ;
+  Alcotest.(check opc) "40" (cut ~rev ~sep:"<>" "1") None ;
+  Alcotest.(check opc) "41" (cut ~rev ~sep:"<>" "123") None ;
+  Alcotest.(check opc) "42" (cut ~rev ~sep:"<>" "<>123") (Some (string "", string "123")) ;
+  Alcotest.(check opc) "43" (cut ~rev ~sep:"<>" "123<>") (Some (string "123", string "")) ;
+  Alcotest.(check opc) "44" (cut ~rev ~sep:"<>" "1<>2<>3") (Some (string "1<>2", string "3")) ;
+  Alcotest.(check opc) "45" (cut ~rev ~sep:"<>" "1<>2<>3 ") (Some (string "1<>2", string "3 ")) ;
+  Alcotest.(check opc) "46" (cut ~rev ~sep:"<>" ">>><>>>><>>>><>>>>") (Some (string ">>><>>>><>>>>", string ">>>")) ;
+  Alcotest.(check opc) "47" (cut ~rev ~sep:"<->" "<->>->") (Some (string "", string ">->")) ;
+  Alcotest.(check opc) "48" (cut ~rev ~sep:"<->" "<-") None ;
+  Alcotest.(check opc) "49" (cut ~rev ~sep:"aa" "aa") (Some (string "", string "")) ;
+  Alcotest.(check opc) "50" (cut ~rev ~sep:"aa" "aaa") (Some (string "a", string "")) ;
+  Alcotest.(check opc) "51" (cut ~rev ~sep:"aa" "aaaa") (Some (string "aa", string "")) ;
+  Alcotest.(check opc) "52" (cut ~rev ~sep:"aa" "aaaaa") (Some (string "aaa", string "")) ;
+  Alcotest.(check opc) "53" (cut ~rev ~sep:"aa" "aaaaaa") (Some (string "aaaa", string "")) ;
+  Alcotest.(check opc) "54" (cut ~rev ~sep:"ab" "afaaaa") None ;
+  (* TODO: incomplete, see [astring]. *)
+;;
+
+let cuts =
+  Alcotest.test_case "cuts" `Quick @@ fun () ->
+  let ls = Alcotest.(list string) in
+  let invalid_cuts_argument = Invalid_argument "cuts: empty separator" in
+  let s str = string ~off:1 ~len:(String.length str) (Fmt.strf "\x00%s\x00" str) in
+  let cuts ?empty ?rev ~sep str =
+    let res = cuts ?empty ?rev ~sep:(s sep) (s str) in
+    List.map Cstruct.to_string res in
+  Alcotest.check_raises "invalid" invalid_cuts_argument
+    (fun () -> ignore (cuts ~sep:"" "")) ;
+  Alcotest.check_raises "invalid" invalid_cuts_argument
+    (fun () -> ignore (cuts ~sep:"" "")) ;
+  Alcotest.(check ls) "0" (cuts ~empty:true  ~sep:"," "") [""] ;
+  Alcotest.(check ls) "1" (cuts ~empty:false ~sep:"," "") [] ;
+  Alcotest.(check ls) "2" (cuts ~empty:true  ~sep:"," "") [""];
+  Alcotest.(check ls) "3" (cuts ~empty:false ~sep:"," "") [];
+  Alcotest.(check ls) "4" (cuts ~empty:true  ~sep:"," ",") [""; ""];
+  Alcotest.(check ls) "5" (cuts ~empty:false ~sep:"," ",") [];
+  Alcotest.(check ls) "6" (cuts ~empty:true  ~sep:"," ",,") [""; ""; ""];
+  Alcotest.(check ls) "7" (cuts ~empty:false ~sep:"," ",,") [];
+  Alcotest.(check ls) "8" (cuts ~empty:true  ~sep:"," ",,,") [""; ""; ""; ""];
+  Alcotest.(check ls) "9" (cuts ~empty:false ~sep:"," ",,,") [];
+  Alcotest.(check ls) "10" (cuts ~empty:true  ~sep:"," "123") ["123"];
+  Alcotest.(check ls) "11" (cuts ~empty:false ~sep:"," "123") ["123"];
+  Alcotest.(check ls) "12" (cuts ~empty:true  ~sep:"," ",123") [""; "123"];
+  Alcotest.(check ls) "13" (cuts ~empty:false ~sep:"," ",123") ["123"];
+  Alcotest.(check ls) "14" (cuts ~empty:true  ~sep:"," "123,") ["123"; ""];
+  Alcotest.(check ls) "15" (cuts ~empty:false ~sep:"," "123,") ["123";];
+  Alcotest.(check ls) "16" (cuts ~empty:true  ~sep:"," "1,2,3") ["1"; "2"; "3"];
+  Alcotest.(check ls) "17" (cuts ~empty:false ~sep:"," "1,2,3") ["1"; "2"; "3"];
+  Alcotest.(check ls) "18" (cuts ~empty:true  ~sep:"," "1, 2, 3") ["1"; " 2"; " 3"];
+  Alcotest.(check ls) "19" (cuts ~empty:false  ~sep:"," "1, 2, 3") ["1"; " 2"; " 3"];
+  Alcotest.(check ls) "20" (cuts ~empty:true ~sep:"," ",1,2,,3,") [""; "1"; "2"; ""; "3"; ""];
+  Alcotest.(check ls) "21" (cuts ~empty:false ~sep:"," ",1,2,,3,") ["1"; "2"; "3";];
+  Alcotest.(check ls) "22" (cuts ~empty:true ~sep:"," ", 1, 2,, 3,")
+    [""; " 1"; " 2"; ""; " 3"; ""];
+  Alcotest.(check ls) "23" (cuts ~empty:false ~sep:"," ", 1, 2,, 3,") [" 1"; " 2";" 3";];
+  Alcotest.(check ls) "24" (cuts ~empty:true ~sep:"<>" "") [""];
+  Alcotest.(check ls) "25" (cuts ~empty:false ~sep:"<>" "") [];
+  Alcotest.(check ls) "26" (cuts ~empty:true ~sep:"<>" "<>") [""; ""];
+  Alcotest.(check ls) "27" (cuts ~empty:false ~sep:"<>" "<>") [];
+  Alcotest.(check ls) "28" (cuts ~empty:true ~sep:"<>" "<><>") [""; ""; ""];
+  Alcotest.(check ls) "29" (cuts ~empty:false ~sep:"<>" "<><>") [];
+  Alcotest.(check ls) "30" (cuts ~empty:true ~sep:"<>" "<><><>") [""; ""; ""; ""];
+  Alcotest.(check ls) "31" (cuts ~empty:false ~sep:"<>" "<><><>") [];
+  Alcotest.(check ls) "32" (cuts ~empty:true ~sep:"<>" "123") [ "123" ];
+  Alcotest.(check ls) "33" (cuts ~empty:false ~sep:"<>" "123") [ "123" ];
+  Alcotest.(check ls) "34" (cuts ~empty:true ~sep:"<>" "<>123") [""; "123"];
+  Alcotest.(check ls) "35" (cuts ~empty:false ~sep:"<>" "<>123") ["123"];
+  Alcotest.(check ls) "36" (cuts ~empty:true ~sep:"<>" "123<>") ["123"; ""];
+  Alcotest.(check ls) "37" (cuts ~empty:false ~sep:"<>" "123<>") ["123"];
+  Alcotest.(check ls) "38" (cuts ~empty:true ~sep:"<>" "1<>2<>3") ["1"; "2"; "3"];
+  Alcotest.(check ls) "39" (cuts ~empty:false ~sep:"<>" "1<>2<>3") ["1"; "2"; "3"];
+  Alcotest.(check ls) "40" (cuts ~empty:true ~sep:"<>" "1<> 2<> 3") ["1"; " 2"; " 3"];
+  Alcotest.(check ls) "41" (cuts ~empty:false ~sep:"<>" "1<> 2<> 3") ["1"; " 2"; " 3"];
+  Alcotest.(check ls) "42" (cuts ~empty:true ~sep:"<>" "<>1<>2<><>3<>")
+    [""; "1"; "2"; ""; "3"; ""];
+  Alcotest.(check ls) "43" (cuts ~empty:false ~sep:"<>" "<>1<>2<><>3<>") ["1"; "2";"3";];
+  Alcotest.(check ls) "44" (cuts ~empty:true ~sep:"<>" "<> 1<> 2<><> 3<>")
+    [""; " 1"; " 2"; ""; " 3";""];
+  Alcotest.(check ls) "45" (cuts ~empty:false ~sep:"<>" "<> 1<> 2<><> 3<>")[" 1"; " 2"; " 3"];
+  Alcotest.(check ls) "46" (cuts ~empty:true ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>>"; ">>>"; ">>>" ];
+  Alcotest.(check ls) "47" (cuts ~empty:false ~sep:"<>" ">>><>>>><>>>><>>>>")
+    [">>>"; ">>>"; ">>>"; ">>>" ];
+  Alcotest.(check ls) "48" (cuts ~empty:true ~sep:"<->" "<->>->") [""; ">->"];
+  Alcotest.(check ls) "49" (cuts ~empty:false ~sep:"<->" "<->>->") [">->"];
+  Alcotest.(check ls) "50" (cuts ~empty:true ~sep:"aa" "aa") [""; ""];
+  Alcotest.(check ls) "51" (cuts ~empty:false ~sep:"aa" "aa") [];
+  Alcotest.(check ls) "52" (cuts ~empty:true ~sep:"aa" "aaa") [""; "a"];
+  Alcotest.(check ls) "53" (cuts ~empty:false ~sep:"aa" "aaa") ["a"];
+  Alcotest.(check ls) "54" (cuts ~empty:true ~sep:"aa" "aaaa") [""; ""; ""];
+  Alcotest.(check ls) "55" (cuts ~empty:false ~sep:"aa" "aaaa") [];
+  Alcotest.(check ls) "56" (cuts ~empty:true ~sep:"aa" "aaaaa") [""; ""; "a"];
+  Alcotest.(check ls) "57" (cuts ~empty:false ~sep:"aa" "aaaaa") ["a"];
+  Alcotest.(check ls) "58" (cuts ~empty:true ~sep:"aa" "aaaaaa") [""; ""; ""; ""];
+  Alcotest.(check ls) "59" (cuts ~empty:false ~sep:"aa" "aaaaaa") [];
+;;
+
+let fields =
+  Alcotest.test_case "fields" `Quick @@ fun () ->
+  let ls = Alcotest.(list string) in
+  let s str = string ~off:1 ~len:(String.length str) (Fmt.strf "\x00%s\x00" str) in
+  let fields ?empty ?is_sep str =
+    let res = fields ?empty ?is_sep (s str) in
+    List.map Cstruct.to_string res in
+  let is_a chr = chr = 'a' in
+  Alcotest.(check ls) "0" (fields ~empty:true "a") ["a"];
+  Alcotest.(check ls) "1" (fields ~empty:false "a") ["a"];
+  Alcotest.(check ls) "2" (fields ~empty:true "abc") ["abc"];
+  Alcotest.(check ls) "3" (fields ~empty:false "abc") ["abc"];
+  Alcotest.(check ls) "4" (fields ~empty:true ~is_sep:is_a "bcdf") ["bcdf"];
+  Alcotest.(check ls) "5" (fields ~empty:false ~is_sep:is_a "bcdf") ["bcdf"];
+  Alcotest.(check ls) "6" (fields ~empty:true "") [""];
+  Alcotest.(check ls) "7" (fields ~empty:false "") [];
+  Alcotest.(check ls) "8" (fields ~empty:true "\n\r") ["";"";""];
+  Alcotest.(check ls) "9" (fields ~empty:false "\n\r") [];
+  Alcotest.(check ls) "10" (fields ~empty:true " \n\rabc") ["";"";"";"abc"];
+  Alcotest.(check ls) "11" (fields ~empty:false " \n\rabc") ["abc"];
+  Alcotest.(check ls) "12" (fields ~empty:true " \n\racd de") ["";"";"";"acd";"de"];
+  Alcotest.(check ls) "13" (fields ~empty:false " \n\racd de") ["acd";"de"];
+  Alcotest.(check ls) "14" (fields ~empty:true " \n\racd de ") ["";"";"";"acd";"de";""];
+  Alcotest.(check ls) "15" (fields ~empty:false " \n\racd de ") ["acd";"de"];
+  Alcotest.(check ls) "16" (fields ~empty:true "\n\racd\nde \r") ["";"";"acd";"de";"";""];
+  Alcotest.(check ls) "17" (fields ~empty:false "\n\racd\nde \r") ["acd";"de"];
+  Alcotest.(check ls) "18" (fields ~empty:true ~is_sep:is_a "") [""];
+  Alcotest.(check ls) "19" (fields ~empty:false ~is_sep:is_a "") [];
+  Alcotest.(check ls) "20" (fields ~empty:true ~is_sep:is_a "abaac aaa")
+    ["";"b";"";"c ";"";"";""];
+  Alcotest.(check ls) "21" (fields ~empty:false ~is_sep:is_a "abaac aaa") ["b"; "c "];
+  Alcotest.(check ls) "22" (fields ~empty:true ~is_sep:is_a "aaaa") ["";"";"";"";""];
+  Alcotest.(check ls) "23" (fields ~empty:false ~is_sep:is_a "aaaa") [];
+  Alcotest.(check ls) "24" (fields ~empty:true ~is_sep:is_a "aaaa ") ["";"";"";"";" "];
+  Alcotest.(check ls) "25" (fields ~empty:false ~is_sep:is_a "aaaa ") [" "];
+  Alcotest.(check ls) "26" (fields ~empty:true ~is_sep:is_a "aaaab") ["";"";"";"";"b"];
+  Alcotest.(check ls) "27" (fields ~empty:false ~is_sep:is_a "aaaab") ["b"];
+  Alcotest.(check ls) "28" (fields ~empty:true ~is_sep:is_a "baaaa") ["b";"";"";"";""];
+  Alcotest.(check ls) "29" (fields ~empty:false ~is_sep:is_a "baaaa") ["b"];
+  Alcotest.(check ls) "30" (fields ~empty:true ~is_sep:is_a "abaaaa") ["";"b";"";"";"";""];
+  Alcotest.(check ls) "31" (fields ~empty:false ~is_sep:is_a "abaaaa") ["b"];
+  Alcotest.(check ls) "32" (fields ~empty:true ~is_sep:is_a "aba") ["";"b";""];
+  Alcotest.(check ls) "33" (fields ~empty:false ~is_sep:is_a "aba") ["b"];
+  Alcotest.(check ls) "34" (fields ~empty:false "tokenize me please")
+    ["tokenize"; "me"; "please"];
+;;
+
+let find =
+  Alcotest.test_case "find" `Quick @@ fun () ->
+  let { Cstruct.buffer= abcbd; _ } = Cstruct.of_string "abcbd" in
+  let empty = buffer ~off:3 ~len:0 abcbd in
+  let a = buffer ~off:0 ~len:1 abcbd in
+  let ab = buffer ~off:0 ~len:2 abcbd in
+  let c = buffer ~off:2 ~len:1 abcbd in
+  let b0 = buffer ~off:1 ~len:1 abcbd in
+  let b1 = buffer ~off:3 ~len:1 abcbd in
+  let abcbd = buffer abcbd in
+  Alcotest.(check (option cstruct)) "0" (find (fun c -> c = 'b') empty) None;
+  Alcotest.(check (option cstruct)) "1" (find ~rev:true (fun c -> c = 'b') empty) None;
+  Alcotest.(check (option cstruct)) "2" (find (fun c -> c = 'b') a) None;
+  Alcotest.(check (option cstruct)) "3" (find ~rev:true (fun c -> c = 'b') a) None;
+  Alcotest.(check (option cstruct)) "4" (find (fun c -> c = 'b') c) None;
+  Alcotest.(check (option cstruct)) "5" (find ~rev:true (fun c -> c = 'b') c) None;
+  Alcotest.(check (option cstruct)) "6" (find (fun c -> c = 'b') abcbd) (Some b0);
+  Alcotest.(check (option cstruct)) "7" (find ~rev:true (fun c -> c = 'b') abcbd) (Some b1);
+  Alcotest.(check (option cstruct)) "8" (find (fun c -> c = 'b') ab) (Some b0);
+  Alcotest.(check (option cstruct)) "9" (find ~rev:true (fun c -> c = 'b') ab) (Some b0);
+;;
+
+let find_sub =
+  Alcotest.test_case "find_sub" `Quick @@ fun () ->
+  let { Cstruct.buffer= abcbd; _ } = Cstruct.of_string "abcbd" in
+  let empty = buffer ~off:3 ~len:0 abcbd in
+  let ab = buffer ~off:0 ~len:2 abcbd in
+  let b0 = buffer ~off:1 ~len:1 abcbd in
+  let b1 = buffer ~off:3 ~len:1 abcbd in
+  let abcbd = buffer abcbd in
+  Alcotest.(check (option cstruct)) "0" (find_sub ~sub:ab empty) None;
+  Alcotest.(check (option cstruct)) "1" (find_sub ~rev:true ~sub:ab empty) None;
+  Alcotest.(check (option cstruct)) "2" (find_sub ~sub:(Cstruct.of_string "") empty) (Some empty);
+  Alcotest.(check (option cstruct)) "3" (find_sub ~rev:true ~sub:(Cstruct.of_string "") empty) (Some empty);
+  Alcotest.(check (option cstruct)) "4" (find_sub ~sub:ab abcbd) (Some ab);
+  Alcotest.(check (option cstruct)) "5" (find_sub ~rev:true ~sub:ab abcbd) (Some ab);
+  Alcotest.(check (option cstruct)) "6" (find_sub ~sub:empty abcbd) (Some (Cstruct.start abcbd));
+  Alcotest.(check (option cstruct)) "7" (find_sub ~rev:true ~sub:empty abcbd)
+    (Some (Cstruct.stop abcbd));
+  Alcotest.(check (option cstruct)) "8" (find_sub ~sub:(Cstruct.of_string "b") abcbd) (Some b0);
+  Alcotest.(check (option cstruct)) "9" (find_sub ~rev:true ~sub:(Cstruct.of_string "b") abcbd) (Some b1);
+  Alcotest.(check (option cstruct)) "10" (find_sub ~sub:b1 ab) (Some b0);
+  Alcotest.(check (option cstruct)) "11" (find_sub ~rev:true ~sub:b1 ab) (Some b0);
+;;
+
+let () = Alcotest.run "cstruct.parse"
+    [ "parse", [ misc; head; start; stop; tail
+               ; is_empty; is_prefix; is_infix; is_suffix
+               ; for_all; exists
+               ; trim
+               ; span
+               ; cut; cuts
+               ; fields
+               ; find; find_sub ] ]

--- a/ppx_test/dune
+++ b/ppx_test/dune
@@ -2,5 +2,6 @@
  (names pcap basic enum)
  (deps http.cap)
  (libraries cstruct-unix sexplib cstruct-sexp)
- (preprocess (pps ppx_cstruct))
+ (preprocess
+  (pps ppx_cstruct))
  (package ppx_cstruct))

--- a/ppx_test/with-lwt/dune
+++ b/ppx_test/with-lwt/dune
@@ -1,4 +1,5 @@
 (executables
  (names ppx_cstruct_and_lwt)
- (preprocess (pps lwt_ppx ppx_cstruct))
+ (preprocess
+  (pps lwt_ppx ppx_cstruct))
  (libraries cstruct lwt lwt.unix))


### PR DESCRIPTION
This PR wants to integrate what is available for [`astring`](https://github.com/dbuenzli/astring) but for `bigarray`/`cstruct`. I think, we missed a middle-step to decode a simple (or not really specified) format.

In the case where:
1) we are able to entirely load contents (with `mmap` for example)
2) we don't have a clear specification of the format (eg. ABNF)

It is interesting to take the advantage of the cheap underlying record of `Cstruct.t` to _parse_ the given contents. On my side, it appears for some cases:
- An example in the documentation is given about the Git tree object
  In `ocaml-git`, it appears that the most common case is to entirely load the Git object (apply an inflation) and decode it as is without the idea of a _kontinuation_ which will load the next chunk. The object is small enough to fit into a large `Cstruct.t` and the [`prompt`](https://github.com/inhabitedtype/angstrom/blob/master/lib/angstrom.ml#L139) step with `angstrom` is unnecessary (but still exists and costs). This API wants to provide (as `astring`) a way to _parse_ contents without an handler about input.

- A format such as the `file`'s database (which is not specified) 
  Some formats are under-specified and small iterations on it during the development is needed to finally be able to compute this kind of format. Tools such as `menhir` are less flexible is this context where we must solve _reduction/shift_ action. Something where the ambiguity is not a problem (or inherent from the format) is needed and I think this API is best for such case.

- Currently, some of my implementation still use `bytes`/`string` due to `astring` where `cstruct` (or `bigarray`) don't provide such API. It is the case about `colombe` or the new implementation of the Smart protocol into `ocaml-git`. I think it can help about an _unification_ of buffers into our eco-system (where the choice will be lead by technical points instead a lack of the eco-system).

So I would like to know the idea of this PR. I added documentation/tests/fuzzers and if the idea is cool for us, we can complete the API with some others functions if people want. (/cc @mirage/core).

PS: the code comes from the @dbuenzli's `astring` package of course with small modifications. Copyrights are respected.