### PR TITLE
Delete length function

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -569,7 +569,6 @@ let buffer ?(off= 0) ?len buffer =
   if off < 0 || len < 0 || off + len > buffer_len then invalid_arg "index out of bounds" ;
   of_bigarray ~off ~len buffer
 
-let length cs = len cs
 let start_pos { off; _ } = off
 let stop_pos { off; len; _ } = off + len
 

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -585,9 +585,6 @@ val start_pos : t -> int
 val stop_pos : t -> int
 (** [stop_pos cs] is [cs]'s stop position in the base {!Cstruct.buffer}. *)
 
-val length : t -> int
-(** [length cs] is the number of bytes in [cs]. *)
-
 val head : ?rev:bool -> t -> char option
 (** [head cs] is [Some (get cs h)] with [h = 0] if [rev = false] (default) or [h
    = length cs - 1] if [rev = true]. [None] is returned if [cs] is empty. *)

--- a/lib_test/parse.ml
+++ b/lib_test/parse.ml
@@ -27,7 +27,7 @@ let misc =
   let sub = string ~off:2 ~len:1 "abc" in
   Alcotest.(check int) "start_pos" (start_pos sub) 2 ;
   Alcotest.(check int) "stop_pos"  (stop_pos sub)  3 ;
-  Alcotest.(check int) "length"    (length sub)    1 ;
+  Alcotest.(check int) "length"    (len sub)    1 ;
   let index_out_of_bounds = Invalid_argument "index out of bounds" in
   Alcotest.check_raises "get" index_out_of_bounds @@ fun () -> ignore @@ get sub 3 ;
   Alcotest.check_raises "get" index_out_of_bounds @@ fun () -> ignore @@ get sub 2 ;
@@ -50,7 +50,7 @@ let head =
 let start =
   Alcotest.test_case "start" `Quick @@ fun () ->
   let empty_pos cs pos =
-    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "length" (len cs) 0 ;
     Alcotest.(check int) "start_pos" (start_pos cs) pos in
   let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
   empty_pos (start @@ string "") 0 ;
@@ -69,7 +69,7 @@ let start =
 let stop =
   Alcotest.test_case "stop" `Quick @@ fun () ->
   let empty_pos cs pos =
-    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "length" (len cs) 0 ;
     Alcotest.(check int) "start_pos" (start_pos cs) pos in
   let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
   empty_pos (stop @@ string "") 0 ;
@@ -88,7 +88,7 @@ let stop =
 let tail =
   Alcotest.test_case "tail" `Quick @@ fun () ->
   let empty_pos cs pos =
-    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "length" (len cs) 0 ;
     Alcotest.(check int) "start_pos" (start_pos cs) pos in
   let { Cstruct.buffer= abc; _ } = Cstruct.of_string "abc" in
   empty_pos (tail @@ string "") 0 ;
@@ -315,7 +315,7 @@ let trim =
   Alcotest.(check cstruct) "trim" (trim ~drop:drop_a aaaabcd) (Cstruct.of_string "bcd") ;
   Alcotest.(check cstruct) "trim" (trim ~drop:drop_a bcdaaaa) (Cstruct.of_string "bcd") ;
   let empty_pos cs pos =
-    Alcotest.(check int) "length" (length cs) 0 ;
+    Alcotest.(check int) "length" (len cs) 0 ;
     Alcotest.(check int) "start_pos" (start_pos cs) pos in
   empty_pos (trim ~drop:drop_a aaaa) 4 ;
   empty_pos (trim (string "    ")) 2 ;


### PR DESCRIPTION
Delete the `length` function which leads incompatibility with several packages when we do:
```ocaml
let length = Cstruct.len x in
let open Cstruct in
...
```