### PR TITLE
Use Cstruct.length instead Cstruct.len (deprecation)

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -586,7 +586,9 @@ val stop_pos : t -> int
 (** [stop_pos cs] is [cs]'s stop position in the base {!Cstruct.buffer}. *)
 
 val length : t -> int
-(** [length cs] is the number of bytes in [cs]. *)
+(** Returns the length of the current cstruct view.  Note that this
+    length is potentially smaller than the actual size of the underlying
+    buffer, as the [sub] or [set_len] functions can construct a smaller view. *)
 
 val head : ?rev:bool -> t -> char option
 (** [head cs] is [Some (get cs h)] with [h = 0] if [rev = false] (default) or [h

--- a/lib/cstruct_cap.ml
+++ b/lib/cstruct_cap.ml
@@ -37,20 +37,20 @@ let of_bytes ?off ?len x =
 let to_string ?(off= 0) ?len t =
   let len = match len with
     | Some len -> len
-    | None -> Cstruct.len t - off in
+    | None -> Cstruct.length t - off in
   Cstruct.copy t off len
 
 let to_bytes ?(off= 0) ?len t =
   let len = match len with
     | Some len -> len
-    | None -> Cstruct.len t - off in
+    | None -> Cstruct.length t - off in
   (* XXX(dinosaure): this is safe when [copy] allocates itself [bytes]
      and uses [Bytes.unsafe_to_string]. *)
   Bytes.unsafe_of_string (Cstruct.copy t off len)
 
 let pp ppf t = Cstruct.hexdump_pp ppf t
 
-let length = Cstruct.len
+let length = Cstruct.length
 
 let blit src ~src_off dst ~dst_off ~len =
   Cstruct.blit src src_off dst dst_off len
@@ -75,9 +75,9 @@ let sub t ~off ~len =
 let concat vss =
   let res = create_unsafe (Cstruct.sum_lengths ~caller:"Cstruct.Cap.concat" vss) in
   let go off v =
-    let len = Cstruct.len v in
+    let len = Cstruct.length v in
     Cstruct.blit v 0 res off len ;
     off + len in
   let len = List.fold_left go 0 vss in
-  assert (len = Cstruct.len res) ;
+  assert (len = Cstruct.length res) ;
   res

--- a/lib/cstruct_sexp.ml
+++ b/lib/cstruct_sexp.ml
@@ -31,7 +31,7 @@ let t_of_sexp = function
   | sexp -> Conv.of_sexp_error "Cstruct.t_of_sexp: atom needed" sexp
 
 let sexp_of_t t =
-  let n   = Cstruct.len t in
+  let n   = Cstruct.length t in
   let str = Bytes.create n in
   Cstruct.blit_to_bytes t 0 str 0 n ;
   (* The following call is safe, since str is not visible elsewhere. *)

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -69,7 +69,7 @@ let concat_samples () =
 
 let concat_random ~n () =
   let rec explode cs =
-    let n = Cstruct.len cs in
+    let n = Cstruct.length cs in
     if n = 0 then [] else
       let k = Random.int (n + 1) in
       Cstruct.sub cs 0 k :: explode (Cstruct.shift cs k) in
@@ -110,7 +110,7 @@ let check_alignment alignment () =
   let buf = Cstruct.create (expected * alignment) in
   (* How many aligned offsets are there in this buffer? *)
   let actual = ref 0 in
-  for i = 0 to Cstruct.len buf - 1 do
+  for i = 0 to Cstruct.length buf - 1 do
     if Cstruct.(check_alignment (shift buf i) alignment) then incr actual
   done;
   Alcotest.(check int) "alignement" expected !actual

--- a/lwt/lwt_cstruct.ml
+++ b/lwt/lwt_cstruct.ml
@@ -25,7 +25,7 @@ let complete op t =
   let rec loop t =
     op t >>= fun n ->
     let t = Cstruct.shift t n in
-    if Cstruct.len t = 0
+    if Cstruct.length t = 0
     then return ()
     else if n = 0
     then fail End_of_file

--- a/ppx_test/pcap.ml
+++ b/ppx_test/pcap.ml
@@ -108,7 +108,7 @@ let print_packet p =
        let window = get_tcpv4_window tcp in
        printf "tcpv4 port %d->%d seq %lu ack %lu win %d off %d flags %s opt %d fin %b syn %b payload_len=%d\n"
          src_port dst_port seqnum
-         acknum window off flags options fin syn (Cstruct.len payload);
+         acknum window off flags options fin syn (Cstruct.length payload);
        ()
      end
      |_ -> printf "unknown ip proto %d\n" proto
@@ -150,7 +150,7 @@ let parse () =
   printf "start parse\n%!";
   let fd = Unix.(openfile "http.cap" [O_RDONLY] 0) in
   let t = Unix_cstruct.of_fd fd in
-  printf "total pcap file length %d\n%!" (Cstruct.len t);
+  printf "total pcap file length %d\n%!" (Cstruct.length t);
 
   let header, body = Cstruct.split t sizeof_pcap_header in
   print_pcap_header header;


### PR DESCRIPTION
In response to #278, this PR use only `Cstruct.length` and deprecate `Cstruct.len` (and fix the documentation). A question still exists: should we rename `lenv` to `lengthv`?