### PR TITLE
Add a deprecation on Cstruct.len (use Cstruct.length instead)

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -337,7 +337,7 @@ val blit_to_string: t -> int -> bytes -> int -> int -> unit
 val memset: t -> int -> unit
 (** [memset t x] sets all the bytes of [t] to [x land 0xff]. *)
 
-val len: t -> int
+val len: t -> int [@@deprecated "len is deprecated, you should use length instead."]
 (** Returns the length of the current cstruct view.  Note that this
     length is potentially smaller than the actual size of the underlying
     buffer, as the [sub] or [set_len] functions can construct a smaller view. *)


### PR DESCRIPTION
According to #282 to be ready (and to not forget) for a possible next release.