### PR TITLE
Remove color from ppx's binary to replicate diff of errors in any contexts

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+version=0.15.0
+disable=true

--- a/ppx/dune
+++ b/ppx/dune
@@ -4,5 +4,6 @@
  (kind ppx_rewriter)
  (wrapped false)
  (ppx_runtime_libraries cstruct stdlib-shims)
- (preprocess (pps ppxlib.metaquot))
+ (preprocess
+  (pps ppxlib.metaquot))
  (libraries sexplib ppxlib bigarray stdlib-shims))

--- a/ppx_test/errors/dune.inc
+++ b/ppx_test/errors/dune.inc
@@ -5,7 +5,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -19,7 +19,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -33,7 +33,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -47,7 +47,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -61,7 +61,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -75,7 +75,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -89,7 +89,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -103,7 +103,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -117,7 +117,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -131,7 +131,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -145,7 +145,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -159,7 +159,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -173,7 +173,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -187,7 +187,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -201,7 +201,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)
@@ -215,7 +215,7 @@
   (action
     (progn
       (with-stderr-to %{targets}
-        (run ./pp.exe --impl %{input}))
+        (run ./pp.exe -no-color --impl %{input}))
       (bash "sed -i.bak '1d' %{targets}"))))
 (rule
   (alias runtest)

--- a/ppx_test/errors/gen_tests.ml
+++ b/ppx_test/errors/gen_tests.ml
@@ -7,7 +7,7 @@ let output_stanzas name =
   (action
     (progn
       (with-stderr-to %%{targets}
-        (run ./pp.exe --impl %%{input}))
+        (run ./pp.exe -no-color --impl %%{input}))
       (bash "sed -i.bak '1d' %%{targets}"))))
 (rule
   (alias runtest)

--- a/ppx_test/errors/pp.ml
+++ b/ppx_test/errors/pp.ml
@@ -7,4 +7,5 @@ let () = at_exit (fun () -> sys_exit 0)
 let () = Clflags.(error_style := Some Short)
 #endif
 
+let () = Clflags.(color := Some Never)
 let () = Ppxlib.Driver.standalone ()


### PR DESCRIPTION
Try to fix #283 about `ppx_cstruct`, we ensure to never outputs with color and, by this way, be safe when we compare expected outputs and what the PPX tool give to us.