### PR TITLE
Use Bytes_val if available

### DIFF
--- a/lib/cstruct_stubs.c
+++ b/lib/cstruct_stubs.c
@@ -23,10 +23,14 @@
 #include <caml/alloc.h>
 #include <caml/bigarray.h>
 
+#ifndef Bytes_val
+#define Bytes_val String_val
+#endif
+
 CAMLprim value
 caml_blit_bigstring_to_string(value val_buf1, value val_ofs1, value val_buf2, value val_ofs2, value val_len)
 {
-  memcpy(String_val(val_buf2) + Long_val(val_ofs2),
+  memcpy(Bytes_val(val_buf2) + Long_val(val_ofs2),
          (char*)Caml_ba_data_val(val_buf1) + Long_val(val_ofs1),
          Long_val(val_len));
   return Val_unit;


### PR DESCRIPTION
Since OCaml 4.06.0, String_val (when safe-string is enabled globally) does a
(const char *) cast. Here, we memcpy into a bytes buffer, and using String_val
emits a C compiler warning ("passing 'const char *' to parameter of type 'void *'
discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]").

To avoid this warning, we use Bytes_val if available (since 4.06.0).