### PR TITLE
Implement host_endian (HE)

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -337,6 +337,15 @@ module LE = struct
   let get_uint64 t i = get_uint64 Sys.big_endian "LE" t i [@@inline]
 end
 
+module HE = struct
+  let set_uint16 t i c = set_uint16 false "HE" t i c [@@inline]
+  let set_uint32 t i c = set_uint32 false "HE" t i c [@@inline]
+  let set_uint64 t i c = set_uint64 false "HE" t i c [@@inline]
+  let get_uint16 t i = get_uint16 false "HE" t i [@@inline]
+  let get_uint32 t i = get_uint32 false "HE" t i [@@inline]
+  let get_uint64 t i = get_uint64 false "HE" t i [@@inline]
+end
+
 let length { len ; _ } = len
 
 (** [sum_lengths ~caller acc l] is [acc] plus the sum of the lengths

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -448,7 +448,43 @@ module LE : sig
   (** [set_uint64 cstr off i] writes the 64 bit long little-endian
       unsigned integer [i] at offset [off] of [cstr].
       @raise Invalid_argument if the buffer is too small. *)
+end
 
+module HE : sig
+
+  (** Get/set host-endian integers of various sizes. The second
+      argument of those functions is the position relative to the
+      current offset of the cstruct. *)
+
+  val get_uint16: t -> int -> uint16
+  (** [get_uint16 cstr off] is the 16 bit long host-endian unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val get_uint32: t -> int -> uint32
+  (** [get_uint32 cstr off] is the 32 bit long host-endian unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val get_uint64: t -> int -> uint64
+  (** [get_uint64 cstr off] is the 64 bit long host-endian unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint16: t -> int -> uint16 -> unit
+  (** [set_uint16 cstr off i] writes the 16 bit long host-endian
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint32: t -> int -> uint32 -> unit
+  (** [set_uint32 cstr off i] writes the 32 bit long host-endian
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint64: t -> int -> uint64 -> unit
+  (** [set_uint64 cstr off i] writes the 64 bit long host-endian
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
 end
 
 (** {2 List of buffers} *)

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -307,6 +307,33 @@ let test_view_bounds_too_small_get_le64 () =
   with
     Invalid_argument _ -> ()
 
+let test_view_bounds_too_small_get_he16 () =
+  let x = Cstruct.create 4 in
+  let x' = Cstruct.sub x 0 1 in
+  try
+    let _ = Cstruct.HE.get_uint16 x' 0 in
+    failwith "test_view_bounds_too_small_get_he16"
+  with
+    Invalid_argument _ -> ()
+
+let test_view_bounds_too_small_get_he32 () =
+  let x = Cstruct.create 8 in
+  let x' = Cstruct.sub x 2 5 in
+  try
+    let _ = Cstruct.HE.get_uint32 x' 2 in
+    failwith "test_view_bounds_too_small_get_he32"
+  with
+    Invalid_argument _ -> ()
+
+let test_view_bounds_too_small_get_he64 () =
+  let x = Cstruct.create 9 in
+  let x' = Cstruct.sub x 1 5 in
+  try
+    let _ = Cstruct.HE.get_uint64 x' 0 in
+    failwith "test_view_bounds_too_small_get_he64"
+  with
+    Invalid_argument _ -> ()
+
 let test_lenv_overflow () =
   if Sys.word_size = 32 then (
     (* free-up some space *)
@@ -338,7 +365,10 @@ let test_subview_containment_get_char,
     test_subview_containment_get_be64,
     test_subview_containment_get_le16,
     test_subview_containment_get_le32,
-    test_subview_containment_get_le64
+    test_subview_containment_get_le64,
+    test_subview_containment_get_he16,
+    test_subview_containment_get_he32,
+    test_subview_containment_get_he64
   =
   let open Cstruct in
   let test get zero () =
@@ -361,7 +391,10 @@ let test_subview_containment_get_char,
   test BE.get_uint64 0L,
   test LE.get_uint16 0,
   test LE.get_uint32 0l,
-  test LE.get_uint64 0L
+  test LE.get_uint64 0L,
+  test HE.get_uint16 0,
+  test HE.get_uint32 0l,
+  test HE.get_uint64 0L
 
 (* Steamroll over a buffer and a contained subview, checking that only the
  * contents of the subview is writable. *)
@@ -372,7 +405,10 @@ let test_subview_containment_set_char,
     test_subview_containment_set_be64,
     test_subview_containment_set_le16,
     test_subview_containment_set_le32,
-    test_subview_containment_set_le64
+    test_subview_containment_set_le64,
+    test_subview_containment_set_he16,
+    test_subview_containment_set_he32,
+    test_subview_containment_set_he64
   =
   let open Cstruct in
   let test set ff () =
@@ -396,7 +432,10 @@ let test_subview_containment_set_char,
   test BE.set_uint64 0xffffffffffffffffL,
   test LE.set_uint16 0xffff,
   test LE.set_uint32 0xffffffffl,
-  test LE.set_uint64 0xffffffffffffffffL
+  test LE.set_uint64 0xffffffffffffffffL,
+  test HE.set_uint16 0xffff,
+  test HE.set_uint32 0xffffffffl,
+  test HE.set_uint64 0xffffffffffffffffL
 
 let regression_244 () =
   let whole = Cstruct.create 44943 in
@@ -438,6 +477,9 @@ let suite = [
   "test_view_bounds_too_small_get_le16" , `Quick, test_view_bounds_too_small_get_le16;
   "test_view_bounds_too_small_get_le32" , `Quick, test_view_bounds_too_small_get_le32;
   "test_view_bounds_too_small_get_le64" , `Quick, test_view_bounds_too_small_get_le64;
+  "test_view_bounds_too_small_get_he16" , `Quick, test_view_bounds_too_small_get_he16;
+  "test_view_bounds_too_small_get_he32" , `Quick, test_view_bounds_too_small_get_he32;
+  "test_view_bounds_too_small_get_he64" , `Quick, test_view_bounds_too_small_get_he64;
   "test_lenv_overflow", `Quick, test_lenv_overflow;
   "test_copyv_overflow", `Quick, test_copyv_overflow;
   "test_subview_containment_get_char", `Quick, test_subview_containment_get_char;
@@ -448,6 +490,9 @@ let suite = [
   "test_subview_containment_get_le16", `Quick, test_subview_containment_get_le16;
   "test_subview_containment_get_le32", `Quick, test_subview_containment_get_le32;
   "test_subview_containment_get_le64", `Quick, test_subview_containment_get_le64;
+  "test_subview_containment_get_le16", `Quick, test_subview_containment_get_he16;
+  "test_subview_containment_get_le32", `Quick, test_subview_containment_get_he32;
+  "test_subview_containment_get_le64", `Quick, test_subview_containment_get_he64;
   "test_subview_containment_set_char", `Quick, test_subview_containment_set_char;
   "test_subview_containment_set_8"   , `Quick, test_subview_containment_set_8;
   "test_subview_containment_set_be16", `Quick, test_subview_containment_set_be16;
@@ -456,5 +501,8 @@ let suite = [
   "test_subview_containment_set_le16", `Quick, test_subview_containment_set_le16;
   "test_subview_containment_set_le32", `Quick, test_subview_containment_set_le32;
   "test_subview_containment_set_le64", `Quick, test_subview_containment_set_le64;
+  "test_subview_containment_set_le16", `Quick, test_subview_containment_set_he16;
+  "test_subview_containment_set_le32", `Quick, test_subview_containment_set_he32;
+  "test_subview_containment_set_le64", `Quick, test_subview_containment_set_he64;
   "regression 244", `Quick, regression_244;
 ]


### PR DESCRIPTION
This addresses issue #72, basically host endianness means "don't swap" for
cstruct, so it's pretty straightforward.

With this I can successfully use the following code on haesbaert/rawlink:

[%%cstruct
type bpf_hdr = {
	bh_sec: uint32_t;
	bh_usec: uint32_t;
	bh_caplen: uint32_t;
	bh_datalen: uint32_t;
	bh_hdrlen: uint16_t;
} [@@host_endian]]