### PR TITLE
since cstruct-unix requires 4.08+, no need for mmap -- use Unix.map_file directly

### DIFF
--- a/cstruct-unix.opam
+++ b/cstruct-unix.opam
@@ -18,7 +18,6 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.0.0"}
   "base-unix"
-  "mmap" {>= "1.2.0"}
   "cstruct" {=version}
 ]
 synopsis: "Access C-like structures directly from OCaml"

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name cstruct_unix)
  (wrapped false)
  (public_name cstruct-unix)
- (libraries cstruct mmap unix))
+ (libraries cstruct unix))

--- a/unix/unix_cstruct.ml
+++ b/unix/unix_cstruct.ml
@@ -15,5 +15,5 @@
  *)
 
 let of_fd fd =
-  let buffer = Bigarray.(array1_of_genarray (Mmap.V1.map_file fd char c_layout false [|-1|])) in
+  let buffer = Bigarray.(array1_of_genarray (Unix.map_file fd char c_layout false [|-1|])) in
   Cstruct.of_bigarray buffer


### PR DESCRIPTION
//cc @dinosaure  -- do you agree?