### PR TITLE
ppx_cstruct: remove stdlib-shims dependency, it requires OCaml 4.08 already

### DIFF
--- a/ppx/dune
+++ b/ppx/dune
@@ -3,7 +3,7 @@
  (public_name ppx_cstruct)
  (kind ppx_rewriter)
  (wrapped false)
- (ppx_runtime_libraries cstruct stdlib-shims)
+ (ppx_runtime_libraries cstruct)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries sexplib ppxlib stdlib-shims))
+ (libraries sexplib ppxlib))

--- a/ppx_cstruct.opam
+++ b/ppx_cstruct.opam
@@ -26,7 +26,6 @@ depends: [
   "cstruct-sexp" {with-test}
   "cppo" {with-test}
   "cstruct-unix" {with-test & =version}
-  "stdlib-shims"
   "ocaml-migrate-parsetree" {>= "2.1.0" & with-test}
   "lwt_ppx" {>= "2.0.2" & with-test}
 ]


### PR DESCRIPTION
somehow overlooked in #298