### PR TITLE
unix: add Cstruct_unix.{read,write,writev,send,recv}

### DIFF
--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,7 @@
  (name cstruct_unix)
  (wrapped false)
  (public_name cstruct-unix)
+ (foreign_stubs
+  (language c)
+  (names read_stubs write_stubs writev_stubs send_stubs recv_stubs))
  (libraries cstruct unix))

--- a/unix/read_stubs.c
+++ b/unix/read_stubs.c
@@ -1,0 +1,70 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+
+#include <stdio.h>
+#include <errno.h>
+
+CAMLprim value stub_cstruct_read(value val_fd, value val_c)
+{
+  CAMLparam2(val_fd, val_c);
+  CAMLlocal3(val_buf, val_ofs, val_len);
+
+  val_buf = Field(val_c, 0);
+  val_ofs = Field(val_c, 1);
+  val_len = Field(val_c, 2);
+
+  void *buf = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+  size_t len = Long_val(val_len);
+  int n = 0;
+
+#ifdef _WIN32
+  int win32err = 0;
+  switch (Descr_kind_val(val_fd))
+  {
+  case KIND_SOCKET:
+    SOCKET s = Socket_val(val_fd);
+
+    caml_release_runtime_system();
+    n = recv(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+      win32_maperr(win32err);
+      unix_error(errno, "read", Nothing);
+    }
+    break;
+  case KIND_HANDLE:
+    HANDLE h = Handle_val(val_fd);
+    DWORD numread;
+    caml_release_runtime_system();
+    int ok = ReadFile(h, buf, len, &numread, NULL);
+    win32err = GetLastError();
+    n = numread;
+    caml_acquire_runtime_system();
+
+    if (!ok)
+    {
+      win32_maperr(win32err);
+      unix_error(errno, "read", Nothing);
+    }
+    break;
+  default:
+    caml_failwith("unknown Descr_kind_val");
+  }
+#else
+  caml_release_runtime_system();
+  n = read(Int_val(val_fd), buf, len);
+  caml_acquire_runtime_system();
+  if (n < 0)
+    unix_error(errno, "read", Nothing);
+#endif
+  CAMLreturn(Val_int(n));
+}

--- a/unix/recv_stubs.c
+++ b/unix/recv_stubs.c
@@ -1,0 +1,63 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+
+#include <stdio.h>
+
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <NTSecAPI.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+#endif
+
+CAMLprim value stub_cstruct_recv(value val_fd, value val_c)
+{
+    CAMLparam2(val_fd, val_c);
+    CAMLlocal3(val_buf, val_ofs, val_len);
+
+    val_buf = Field(val_c, 0);
+    val_ofs = Field(val_c, 1);
+    val_len = Field(val_c, 2);
+
+    void *buf = (void *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+    size_t len = (size_t)Long_val(val_len);
+    int n = 0;
+#ifdef WIN32
+    int win32err = 0;
+    if (Descr_kind_val(val_fd) != KIND_SOCKET)
+        unix_error(EINVAL, "recv", Nothing);
+
+    SOCKET s = Socket_val(val_fd);
+
+    caml_release_runtime_system();
+    n = recv(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+        win32_maperr(win32err);
+        unix_error(errno, "recv", Nothing);
+    }
+#else
+    int fd = Int_val(val_fd);
+
+    caml_release_runtime_system();
+    n = recv(fd, buf, len, 0);
+    caml_acquire_runtime_system();
+
+    if (n < 0)
+        unix_error(errno, "recv", Nothing);
+#endif
+    CAMLreturn(Val_int(n));
+}

--- a/unix/send_stubs.c
+++ b/unix/send_stubs.c
@@ -1,0 +1,62 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+
+#include <stdio.h>
+
+#ifdef WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <NTSecAPI.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+#endif
+
+CAMLprim value stub_cstruct_send(value val_fd, value val_c)
+{
+    CAMLparam2(val_fd, val_c);
+    CAMLlocal3(val_buf, val_ofs, val_len);
+
+    val_buf = Field(val_c, 0);
+    val_ofs = Field(val_c, 1);
+    val_len = Field(val_c, 2);
+
+    const char *buf = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+    size_t len = (size_t)Long_val(val_len);
+    int n = 0;
+
+#ifdef WIN32
+    int win32err = 0;
+    if (Descr_kind_val(val_fd) != KIND_SOCKET)
+        unix_error(EINVAL, "send", Nothing);
+
+    SOCKET s = Socket_val(val_fd);
+    caml_release_runtime_system();
+    n = send(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+        win32_maperr(win32err);
+        unix_error(errno, "send", Nothing);
+    }
+#else
+    int fd = Int_val(val_fd);
+
+    caml_release_runtime_system();
+    n = send(fd, buf, len, 0);
+    caml_acquire_runtime_system();
+    if (n < 0)
+        unix_error(errno, "send", Nothing);
+#endif
+    CAMLreturn(Val_int(n));
+}

--- a/unix/unix_cstruct.ml
+++ b/unix/unix_cstruct.ml
@@ -17,3 +17,60 @@
 let of_fd fd =
   let buffer = Bigarray.(array1_of_genarray (Unix.map_file fd char c_layout false [|-1|])) in
   Cstruct.of_bigarray buffer
+
+type buffer = (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+
+(* Returns 0 if there is no writev *)
+external stub_iov_max: unit -> int = "stub_cstruct_iov_max"
+
+external stub_write: Unix.file_descr -> (buffer * int * int) -> int = "stub_cstruct_write"
+
+external stub_writev: Unix.file_descr -> (buffer * int * int) list -> int = "stub_cstruct_writev"
+
+let iov_max = stub_iov_max ()
+
+(* return the first n fragments, suitable for writev *)
+let rec first n rev_acc = function
+| [] -> List.rev rev_acc
+| _ when n = 0 -> List.rev rev_acc
+| x :: xs -> first (n - 1) (x :: rev_acc) xs
+
+(* shift a list of fragments along by n bytes *)
+let rec shift t x =
+  if x = 0 then t else match t with
+  | [] -> invalid_arg "foo"
+  | y :: ys ->
+    let y' = Cstruct.length y in
+    if y' > x
+    then Cstruct.shift y x :: ys
+    else shift ys (x - y')
+
+let rec write fd buf =
+  if Cstruct.length buf > 0 then begin
+    let n = stub_write fd (buf.Cstruct.buffer, buf.Cstruct.off, buf.Cstruct.len) in
+    write fd @@ Cstruct.shift buf n
+  end
+
+let writev fd bufs =
+  let rec use_writev = function
+    | [] -> ()
+    | remaining ->
+      (* write at most iov_max at a time *)
+      let to_send = first iov_max [] remaining in
+      let n = stub_writev fd (List.map (fun x -> x.Cstruct.buffer, x.Cstruct.off, x.Cstruct.len) to_send) in
+      let rest = shift remaining n in
+      use_writev rest in
+  let use_write_fallback = List.iter (write fd) in
+  (if iov_max = 0 then use_write_fallback else use_writev) bufs
+
+external stub_send: Unix.file_descr -> (buffer * int * int) -> int = "stub_cstruct_send"
+
+external stub_recv: Unix.file_descr -> (buffer * int * int) -> int = "stub_cstruct_recv"
+
+let send fd x = stub_send fd (x.Cstruct.buffer, x.Cstruct.off, x.Cstruct.len)
+
+let recv fd x = stub_recv fd (x.Cstruct.buffer, x.Cstruct.off, x.Cstruct.len)
+
+external stub_read: Unix.file_descr -> (buffer * int * int) -> int = "stub_cstruct_read"
+
+let read fd x = stub_read fd (x.Cstruct.buffer, x.Cstruct.off, x.Cstruct.len)

--- a/unix/unix_cstruct.mli
+++ b/unix/unix_cstruct.mli
@@ -1,5 +1,6 @@
 (*
  * Copyright (c) 2012 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2022 David Scott <dave@recoil.org>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -18,3 +19,23 @@
 
 val of_fd : Unix.file_descr -> Cstruct.t
 (** [of_fd fd] memory maps the [fd] and returns a cstruct *)
+
+val read: Unix.file_descr -> Cstruct.t -> int
+(** [read fd cs] reads from the file descriptor into the buffer, returning the number of bytes read.
+    Similar to Unix.read. *)
+
+val write: Unix.file_descr -> Cstruct.t -> unit
+(** [write fd cs] writes the whole Cstruct to the file descriptor.
+    Similar to Unix.write. *)
+
+val writev: Unix.file_descr -> Cstruct.t list -> unit
+(** [writev fd cs] writes the whole list of Cstructs to the file descriptor.
+    Similar to Unix.write. *)
+
+val send: Unix.file_descr -> Cstruct.t -> int
+(** [send fd c] sends a message from a socket. This can be used to send a datagram.
+    If only a partial send is possible, the return argument is how many bytes were sent. *)
+
+val recv: Unix.file_descr -> Cstruct.t -> int
+(** [recv fd c] receives a message from a socket. This can be used to receive a datagram.
+    If only a partial receive is possible, the return argument is now many bytes were received. *)

--- a/unix/write_stubs.c
+++ b/unix/write_stubs.c
@@ -1,0 +1,69 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+
+#include <stdio.h>
+#include <errno.h>
+
+CAMLprim value stub_cstruct_write(value val_fd, value val_c)
+{
+  CAMLparam2(val_fd, val_c);
+  CAMLlocal3(val_buf, val_ofs, val_len);
+  val_buf = Field(val_c, 0);
+  val_ofs = Field(val_c, 1);
+  val_len = Field(val_c, 2);
+  void *buf = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+  size_t len = Long_val(val_len);
+  int n = 0;
+
+#ifdef _WIN32
+  int win32err = 0;
+  switch (Descr_kind_val(val_fd))
+  {
+  case KIND_SOCKET:
+    SOCKET s = Socket_val(val_fd);
+
+    caml_release_runtime_system();
+    n = send(s, buf, len, 0);
+    win32err = WSAGetLastError();
+    caml_acquire_runtime_system();
+
+    if (n == SOCKET_ERROR)
+    {
+      win32_maperr(win32err);
+      unix_error(errno, "writev", Nothing);
+    }
+    break;
+  case KIND_HANDLE:
+    HANDLE h = Handle_val(val_fd);
+    DWORD numwritten;
+    caml_release_runtime_system();
+    int ok = WriteFile(h, buf, len, &numwritten, NULL);
+    win32err = GetLastError();
+
+    n = numwritten;
+    caml_acquire_runtime_system();
+
+    if (!ok)
+    {
+      win32_maperr(win32err);
+      unix_error(errno, "writev", Nothing);
+    }
+    break;
+  default:
+    caml_failwith("unknown Descr_kind_val");
+  }
+#else
+  caml_release_runtime_system();
+  n = write(Int_val(val_fd), buf, len);
+  caml_acquire_runtime_system();
+  if (n < 0)
+    unix_error(errno, "write", Nothing);
+#endif
+  CAMLreturn(Val_int(n));
+}

--- a/unix/writev_stubs.c
+++ b/unix/writev_stubs.c
@@ -1,0 +1,69 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/custom.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/threads.h>
+
+#include <stdio.h>
+#include <errno.h>
+#ifndef _WIN32
+#include <sys/uio.h>
+#include <limits.h>
+#endif
+
+CAMLprim
+    value
+    stub_cstruct_iov_max(value unit)
+{
+  CAMLparam1(unit);
+#ifdef IOV_MAX
+  CAMLreturn(Val_int(IOV_MAX));
+#else
+  CAMLreturn(Val_int(0));
+#endif
+}
+
+CAMLprim
+    value
+    stub_cstruct_writev(value fd, value val_list)
+{
+  CAMLparam2(fd, val_list);
+  CAMLlocal5(next, head, val_buf, val_ofs, val_len);
+  int i;
+#ifdef _WIN32
+  caml_failwith("writev is not supported on Win32");
+#else
+  struct iovec iovec[IOV_MAX];
+  int c_fd = Int_val(fd);
+
+  next = val_list;
+  /* Calculate the length of the val_list */
+  int length = 0;
+  for (next = val_list; next != Val_emptylist; next = Field(next, 1))
+    length++;
+  /* Only copy up to the iovec array size */
+  if (length > IOV_MAX)
+    length = IOV_MAX;
+  next = val_list;
+  for (i = 0; i < length; i++)
+  {
+    head = Field(next, 0);
+    val_buf = Field(head, 0);
+    val_ofs = Field(head, 1);
+    val_len = Field(head, 2);
+    iovec[i].iov_base = (char *)Caml_ba_data_val(val_buf) + Long_val(val_ofs);
+    iovec[i].iov_len = Long_val(val_len);
+    next = Field(next, 1);
+  }
+
+  caml_release_runtime_system();
+  ssize_t n = writev(c_fd, iovec, length);
+  caml_acquire_runtime_system();
+  if (n < 0)
+    unix_error(errno, "writev", Nothing);
+  CAMLreturn(Val_int(n));
+#endif
+}

--- a/unix_test/dune
+++ b/unix_test/dune
@@ -1,0 +1,10 @@
+(executable
+ (libraries cstruct alcotest cstruct-unix threads)
+ (modules tests)
+ (name tests))
+
+(rule
+ (alias runtest)
+ (package cstruct-unix)
+ (action
+  (run ./tests.exe -e)))

--- a/unix_test/tests.ml
+++ b/unix_test/tests.ml
@@ -1,0 +1,143 @@
+
+let mk_temp_dir () =
+  let rand_num = Random.int 1000000 |> string_of_int in
+  let tmp_dir = Filename.get_temp_dir_name () ^ "/test-cstruct-unix-" ^ rand_num in
+  try
+    Unix.mkdir tmp_dir 0o700;
+    tmp_dir
+  with Unix.Unix_error(Unix.EEXIST, _, _) ->
+    (* re-use the old one *)
+    tmp_dir
+  | e -> raise (Sys_error ("Cannot create temp dir " ^ tmp_dir ^ " " ^ (Printexc.to_string e)))
+
+let rmdir path =
+  (* non-recursive for safety *)
+  match Sys.is_directory path with
+  | true ->
+    Sys.readdir path |>
+    Array.iter (fun name -> Sys.remove (Filename.concat path name));
+    Unix.rmdir path
+  | false -> Sys.remove path
+
+let finally f g =
+  try
+    let r = f () in
+    g ();
+    r
+  with e ->
+    g ();
+    raise e
+
+let with_tmp_dir f =
+  let dir = mk_temp_dir () in
+  finally (fun () -> f dir) (fun () -> rmdir dir)
+
+let test_message_list =[
+  Cstruct.of_string "hello";
+  Cstruct.of_string " ";
+  Cstruct.of_string "cstruct";
+  Cstruct.create 0;
+  Cstruct.of_string " ";
+  Cstruct.of_string "world";
+]
+
+let read_and_check fd sent_message =
+  let expected = Cstruct.(to_string @@ concat sent_message) in
+  let buf = Cstruct.create 1024 in
+  let read = ref 0 in
+  while !read < (String.length expected) do
+    let n = Unix_cstruct.read fd (Cstruct.shift buf !read) in
+    if n = 0 then raise End_of_file;
+    read := !read + n
+  done;
+  let actual = Cstruct.(to_string @@ sub buf 0 !read) in
+  Alcotest.(check string) "read contents" expected actual
+
+let test_writev_file () =
+  with_tmp_dir
+    (fun dir ->
+      let test = Filename.concat dir "test" in
+      let fd = Unix.openfile test [ Unix.O_CREAT; Unix.O_RDWR ] 0o644 in
+      finally (fun () ->
+        Unix_cstruct.writev fd test_message_list;
+        let ofs = Unix.lseek fd 0 Unix.SEEK_SET in
+        Alcotest.(check int) "file offset" 0 ofs;
+        read_and_check fd test_message_list
+      ) (fun () -> Unix.close fd)
+    )
+
+let with_sock_stream f =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  finally (fun () -> f s) (fun () -> Unix.close s)
+
+let localhost = Unix.inet_addr_of_string "127.0.0.1"
+
+let bind_random_port s =
+  Unix.bind s (Unix.ADDR_INET(localhost, 0));
+  match Unix.getsockname s with
+    | Unix.ADDR_INET(_, port) -> port
+    | _ -> assert false
+
+let test_writev_socket () =
+  with_sock_stream (fun s ->
+    let port = bind_random_port s in
+    Unix.listen s 1;
+    let t = Thread.create (fun () ->
+      let client, _ = Unix.accept s in
+      finally
+        (fun () ->
+          read_and_check client test_message_list
+        ) (fun () -> Unix.close client)
+    ) () in
+    with_sock_stream (fun c ->
+      Unix.connect c (Unix.ADDR_INET(localhost, port));
+      Unix_cstruct.writev c test_message_list;
+    );
+    Thread.join t
+  )
+
+let with_sock_dgram f =
+  let s = Unix.socket Unix.PF_INET Unix.SOCK_DGRAM 0 in
+  finally (fun () -> f s) (fun () -> Unix.close s)
+
+let with_mutex m f =
+  Mutex.lock m;
+  finally f (fun () -> Mutex.unlock m)
+
+let test_send_recv () =
+  let test_message = Cstruct.concat test_message_list in
+  with_sock_dgram (fun s ->
+    let port = bind_random_port s in
+    let m = Mutex.create () in
+    let finished = ref false in
+    let t = Thread.create (fun () ->
+          let buf = Cstruct.create 1024 in
+          let n = Unix_cstruct.recv s buf in
+          Alcotest.(check int) "recv length" (Cstruct.length test_message) n;
+          let expected = Cstruct.to_string test_message in
+          let actual = Cstruct.(to_string @@ sub buf 0 n) in
+          Alcotest.(check string) "read contents" expected actual;
+          with_mutex m (fun () -> finished := true)
+    ) () in
+    with_sock_dgram (fun c ->
+      Unix.connect c (Unix.ADDR_INET(localhost, port));
+      while with_mutex m (fun () -> not !finished) do
+        let n = Unix_cstruct.send c test_message in
+        Alcotest.(check int) "send length" (Cstruct.length test_message) n;
+        Thread.delay 0.1
+      done
+    );
+    Thread.join t
+  )
+
+let suite = [
+  "writev", [
+    "test read and writev via a file", `Quick, test_writev_file;
+    "test read and writev via a socket", `Quick, test_writev_socket;
+  ];
+  "send recv", [
+    "test send and recv", `Quick, test_send_recv;
+  ]
+]
+
+let () = Alcotest.run "cstruct.unix" suite


### PR DESCRIPTION
This is useful for direct-style code to avoid copying Cstructs into temporary byte buffers to use the `Unix.` API.

Signed-off-by: David Scott <dave@recoil.org>