### PR TITLE
add `Cstruct.sub_copy`

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -217,6 +217,11 @@ let blit src srcoff dst dstoff len =
     unsafe_blit_bigstring_to_bigstring src.buffer (src.off+srcoff) dst.buffer
       (dst.off+dstoff) len
 
+let sub_copy cstr off len : t =
+  let cstr2 = create_unsafe len in
+  blit cstr off cstr2 0 len;
+  cstr2
+
 let blit_from_string src srcoff dst dstoff len =
   if len < 0 || srcoff < 0 || dstoff < 0 || String.length src - srcoff < len then
     err_blit_from_string_src src dst srcoff len

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -282,6 +282,11 @@ val sub: t -> int -> int -> t
 (** [sub cstr off len] is [{ t with off = t.off + off; len }]
     @raise Invalid_argument if the offset exceeds cstruct length. *)
 
+val sub_copy: t -> int -> int -> t
+(** [sub_copy cstr off len] is a new copy of [sub cstr off len],
+    that does not share the underlying buffer of [cstr].
+    @raise Invalid_argument if the offset exceeds cstruct length. *)
+
 val shift: t -> int -> t
 (** [shift cstr len] is [{ cstr with off=t.off+len; len=t.len-len }]
     @raise Invalid_argument if the offset exceeds cstruct length. *)

--- a/lib/cstruct_cap.ml
+++ b/lib/cstruct_cap.ml
@@ -56,6 +56,10 @@ let sub t ~off ~len =
   Cstruct.sub t off len
 [@@inline]
 
+let sub_copy t ~off ~len =
+  Cstruct.sub_copy t off len
+[@@inline]
+
 let unsafe_to_bigarray = Cstruct.to_bigarray
 
 let concat vss =

--- a/lib/cstruct_cap.mli
+++ b/lib/cstruct_cap.mli
@@ -146,6 +146,14 @@ val sub : 'a t -> off:int -> len:int -> 'a t
 
     @raise Invalid_argument if the offset exceeds [t] length. *)
 
+val sub_copy : 'a t -> off:int -> len:int -> rdwr t
+(** [sub_copy t ~off ~len] is a new copy of [sub t ~off ~len],
+    that does not share the underlying buffer of [t].
+    The returned value has read-write capabilities because it doesn't
+    affect [t].
+
+    @raise Invalid_argument if the offset exceeds [t] length. *)
+
 val shift : 'a t -> int -> 'a t
 (** [shift t len] returns a proxy which shares the underlying buffer of [t]. The
     returned value starts [len] bytes later than the given [t]. The returned

--- a/lib_test/bounds.ml
+++ b/lib_test/bounds.ml
@@ -71,6 +71,19 @@ let test_sub () =
   Alcotest.(check int) "sub 3" 20 z.Cstruct.off;
   Alcotest.(check int) "sub 4" 60 z.Cstruct.len
 
+let test_sub_copy () =
+  let x = Cstruct.create 100 in
+  let y = Cstruct.sub_copy x 10 80 in
+  Alcotest.(check int) "sub_copy 1" 0 y.Cstruct.off;
+  Alcotest.(check int) "sub_copy 2" 80 y.Cstruct.len;
+  let z = Cstruct.sub_copy y 10 60 in
+  Alcotest.(check int) "sub_copy 3" 0 z.Cstruct.off;
+  Alcotest.(check int) "sub_copy 4" 60 z.Cstruct.len;
+  Cstruct.set_uint8 x 50 42;
+  Alcotest.(check int) "x changed" 42 (Cstruct.get_uint8 x 50);
+  Alcotest.(check int) "y unchanged" 0 (Cstruct.get_uint8 y 50);
+  ()
+
 let test_negative_sub () =
   let x = Cstruct.create 2 in
   let y = Cstruct.sub x 1 1 in
@@ -453,6 +466,7 @@ let suite = [
   "test negative shift", `Quick, test_negative_shift;
   "test bad positive shift", `Quick, test_bad_positive_shift;
   "test sub", `Quick, test_sub;
+  "test sub_copy", `Quick, test_sub_copy;
   "test negative sub", `Quick, test_negative_sub;
   "test sub len too big", `Quick, test_sub_len_too_big;
   "test sub len too small", `Quick, test_sub_len_too_small;


### PR DESCRIPTION
I was looking for a way of copying a `Cstruct.t` _without sharing the buffer_ (because the buffer is used for the next IO read), and did not find one.