### PR TITLE
add to_hex_string

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -54,6 +54,7 @@ let err_sub t = err "Cstruct.sub: %a off=%d len=%d" pp_t t
 let err_shift t = err "Cstruct.shift %a %d" pp_t t
 let err_shiftv n = err "Cstruct.shiftv short by %d" n
 let err_copy t = err "Cstruct.copy %a off=%d len=%d" pp_t t
+let err_to_hex_string t = err "Cstruct.to_hex_string %a off=%d len=%d" pp_t t
 let err_blit_src src dst =
   err "Cstruct.blit src=%a dst=%a src-off=%d len=%d" pp_t src pp_t dst
 let err_blit_dst src dst =
@@ -400,6 +401,28 @@ let to_string ?(off=0) ?len:sz t =
   (* The following call is safe, since this is the only reference to the
      freshly-created value built by [to_bytes t]. *)
   copy t off len
+
+let to_hex_string ?(off=0) ?len:sz t : string =
+  let[@inline] nibble_to_char (i:int) : char =
+    if i < 10 then
+      Char.chr (i + Char.code '0')
+    else
+      Char.chr (i - 10 + Char.code 'a')
+  in
+
+  let len = match sz with None -> length t - off | Some l -> l in
+  if len < 0 || off < 0 || t.len - off < len then
+    err_to_hex_string t off len
+  else (
+    let out = Bytes.create (2 * len) in
+    for i=0 to len-1 do
+      let c = Char.code @@ Bigarray.Array1.get t.buffer (i+off) in
+      Bytes.set out (2*i) (nibble_to_char (c lsr 4));
+      Bytes.set out (2*i+1) (nibble_to_char (c land 0xf));
+    done;
+    Bytes.unsafe_to_string out
+  )
+
 
 let to_bytes ?off ?len t =
   Bytes.unsafe_of_string (to_string ?off ?len t)

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -352,7 +352,15 @@ val to_string: ?off:int -> ?len:int -> t -> string
     [len] (default [Cstruct.len t - off]) into it, and return that string.
 
     @raise Invalid_argument if [off] or [len] is negative, or
-    [Cstruct.len str - off] < [len]. *)
+    [Cstruct.len t - off] < [len]. *)
+
+val to_hex_string : ?off:int -> ?len:int -> t -> string
+(** [to_hex_string ~off ~len t] is a fresh OCaml [string] containing
+    the hex representation of [sub t off len]. It is therefore of length
+    [2 * len]. This string can be read back into a Cstruct using {!of_hex}.
+    @raise Invalid_argument if [off] or [len] is negative, or
+      if [Cstruct.len t - off < len].
+    @since 6.2 *)
 
 val to_bytes: ?off:int -> ?len:int -> t -> bytes
 (** [to_bytes ~off ~len t] will allocate a fresh OCaml [bytes] and copy the

--- a/lib_test/tests.ml
+++ b/lib_test/tests.ml
@@ -166,6 +166,25 @@ let hexdump_small () =
 let hex_multiline =
   Cstruct.of_hex "000102030405060708090a0b0c0d0e0f101112"
 
+let hex_to_string_empty () =
+  let c = Cstruct.of_string "" in
+  let s = Cstruct.to_hex_string c in
+  assert_string_equal ~msg:"encoded" s ""
+
+let hex_to_string_small () =
+  let c = Cstruct.of_string "hello world \x00 !" in
+  let s = Cstruct.to_hex_string c in
+  assert_string_equal ~msg:"encoded" "68656c6c6f20776f726c6420002021" s;
+  let c' = Cstruct.of_hex s in
+  assert_cs_equal ~msg:"decoded again" c c'
+
+let hex_to_string_small_slice () =
+  let c = Cstruct.of_string "This_1s Not @ Dr1LL" in
+  let s = Cstruct.to_hex_string ~off:2 ~len:11 c in
+  assert_string_equal ~msg:"encoded" "69735f3173204e6f742040" s;
+  let c' = Cstruct.of_hex s in
+  assert_cs_equal ~msg:"decoded again" (Cstruct.sub c 2 11) c'
+
 let hexdump_multiline () =
   test_hexdump
     hex_multiline
@@ -224,7 +243,13 @@ let suite = [
     "aligned", `Quick, hexdump_aligned;
     "aligned to half", `Quick, hexdump_aligned_to_half;
     "in box", `Quick, hexdump_in_box;
+  ];
+  "hex_to_string", [
+    "empty", `Quick, hex_to_string_empty;
+    "small", `Quick, hex_to_string_small;
+    "small_slice", `Quick, hex_to_string_small_slice;
   ]
+
 ]
 
 let () = Alcotest.run "cstruct" (("bounds", Bounds.suite) :: suite)


### PR DESCRIPTION
The function `of_hex` lacks an inverse function. The hexdump functions are
useful when you want to look at them with a cup of coffee in hand, a frown
on your face, and a growing feeling of existential despair; but if you just
want to copy/paste data into a `utop` or a test file, `to_hex_string` will
be more convenient as you can just write `Cstruct.of_hex "d3adb33f"` with
the obtained string.

