### PR TITLE
Deprecate copy

### DIFF
--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -292,8 +292,10 @@ val shift: t -> int -> t
     @raise Invalid_argument if the offset exceeds cstruct length. *)
 
 val copy: t -> int -> int -> string
+[@@ocaml.alert deprecated "this is just like [to_string] without defaults, were you looking for [sub_copy]?"]
 (** [copy cstr off len] is the string representation of the segment of
-    [t] starting at [off] of size [len].
+    [t] starting at [off] of size [len]. It is equivalent to
+    [Cstruct.to_string cstr ~off ~len].
     @raise Invalid_argument if [off] and [len] do not designate a
     valid segment of [t]. *)
 

--- a/lib/cstruct_cap.mli
+++ b/lib/cstruct_cap.mli
@@ -177,6 +177,10 @@ val split : ?start:int -> 'a t -> int -> 'a t * 'a t
     @raise Invalid_argument if [start] exceeds the length of [t],
     or if there is a bounds violation of [t] via [len + start]. *)
 
+val copy : 'a t -> int -> int -> string
+[@@ocaml.alert deprecated "this is just like [to_string] without defaults, were you looking for [sub_copy]?"]
+(** [copy cstr off len] is the same as [Cstruct.to_string cstr ~off ~len]. *)
+
 (** {2 Construction from existing t} *)
 
 val append : 'a rd t -> 'b rd t -> rdwr t

--- a/ppx/ppx_cstruct.ml
+++ b/ppx/ppx_cstruct.ml
@@ -298,7 +298,7 @@ let op_expr loc s = function
   | Op_set f -> set_expr loc s f
   | Op_copy f ->
     let len = width_of_field f in
-    [%expr fun src -> Cstruct.copy src [%e Ast.eint ~loc f.off] [%e Ast.eint ~loc len] ]
+    [%expr fun src -> Cstruct.to_string src ~off:[%e Ast.eint ~loc f.off] ~len:[%e Ast.eint ~loc len] ]
   | Op_blit f ->
     let len = width_of_field f in
     [%expr fun src srcoff dst ->


### PR DESCRIPTION
As briefly discussed in https://github.com/mirage/ocaml-cstruct/pull/305#issuecomment-1424637704 `Cstruct.copy` is basically `Cstruct.to_string` without defaults/labelled arguments. The name `copy` suggests it creates a cstruct from a cstruct, but it creates a string. Instead, the new `Cstruct.sub_copy` makes a cstruct copy of a cstruct. I propose we deprecate `Cstruct.copy` with a message suggesting to use either `Cstruct.to_string` or `Cstruct.sub_copy`, and some time in the future we may rename `Cstruct.sub_copy` to `Cstruct.copy`.

The ppx still uses names like `copy_struct_field`. It's unclear to me if we want to preserve this, or try to deprecate it in favor of `to_string_struct_field` (or similar).