### PR TITLE
Add sexp_of cenum attribute, use sexplib0

### DIFF
--- a/ppx_test/with-sexp-of/dune
+++ b/ppx_test/with-sexp-of/dune
@@ -1,0 +1,11 @@
+(executable
+ (name ppx_cstruct_and_sexp_of)
+ (preprocess
+  (pps ppx_cstruct ppx_sexp_conv -- -no-check))
+ (libraries cstruct sexplib0 cstruct-sexp))
+
+(rule
+ (alias runtest)
+ (package ppx_cstruct)
+ (action
+  (run ./ppx_cstruct_and_sexp_of.exe)))

--- a/ppx_test/with-sexp-of/ppx_cstruct_and_sexp_of.ml
+++ b/ppx_test/with-sexp-of/ppx_cstruct_and_sexp_of.ml
@@ -1,0 +1,6 @@
+(* inspect output with [dune describe pp ppx_test/with-sexp-of/ppx_cstruct_and_sexp_of.ml] *)
+[%%cenum
+type enum =
+  | One [@id 1]
+  | Three [@id 3]
+[@@uint8_t][@@sexp_of]]


### PR DESCRIPTION
The `sexp_of_*` functions now return `Sexplib0.Sexp.t` instead of `Sexplib.Sexp.t`. The `cenum` attribute `[@@sexp_of]` is like `[@@sexp]` except it only produces the `sexp_of*` function. This allows for generating `sexp_of` converters without depending on the full sexplib library.