### PR TITLE
Add Unsafe operations

### DIFF
--- a/lib/cstruct.ml
+++ b/lib/cstruct.ml
@@ -297,61 +297,98 @@ external swap16 : int -> int = "%bswap16"
 external swap32 : int32 -> int32 = "%bswap_int32"
 external swap64 : int64 -> int64 = "%bswap_int64"
 
-let set_uint16 swap p t i c =
-  if i > t.len - 2 || i < 0 then err_invalid_bounds (p ^ ".set_uint16") t i 2
-  else ba_set_int16 t.buffer (t.off+i) (if swap then swap16 c else c) [@@inline]
+module type Swap = sig
+  val swap : bool
+  val name : string
+end
 
-let set_uint32 swap p t i c =
-  if i > t.len - 4 || i < 0 then err_invalid_bounds (p ^ ".set_uint32") t i 4
-  else ba_set_int32 t.buffer (t.off+i) (if swap then swap32 c else c) [@@inline]
+module type GetterSetter = sig
+  val get_uint16: t -> int -> uint16
+  val get_uint32: t -> int -> uint32
+  val get_uint64: t -> int -> uint64
+  val set_uint16: t -> int -> uint16 -> unit
+  val set_uint32: t -> int -> uint32 -> unit
+  val set_uint64: t -> int -> uint64 -> unit
+end
 
-let set_uint64 swap p t i c =
-  if i > t.len - 8 || i < 0 then err_invalid_bounds (p ^ ".set_uint64") t i 8
-  else ba_set_int64 t.buffer (t.off+i) (if swap then swap64 c else c) [@@inline]
+module type GetterSetterWithSwap = sig
+  module Swap : Swap
+  include GetterSetter
+end
 
-let get_uint16 swap p t i =
-  if i > t.len - 2 || i < 0 then err_invalid_bounds (p ^ ".get_uint16") t i 2
-  else
+module Unsafe(Swap : Swap) = struct
+  module Swap = Swap
+
+  let set_uint16 t i c =
+    ba_set_int16 t.buffer (t.off+i) (if Swap.swap then swap16 c else c) [@@inline]
+
+  let set_uint32 t i c =
+    ba_set_int32 t.buffer (t.off+i) (if Swap.swap then swap32 c else c) [@@inline]
+
+  let set_uint64 t i c =
+    ba_set_int64 t.buffer (t.off+i) (if Swap.swap then swap64 c else c) [@@inline]
+
+  let get_uint16 t i =
     let r = ba_get_int16 t.buffer (t.off+i) in
-    if swap then swap16 r else r [@@inline]
+    if Swap.swap then swap16 r else r [@@inline]
 
-let get_uint32 swap p t i =
-  if i > t.len - 4 || i < 0 then err_invalid_bounds (p ^ ".get_uint32") t i 4
-  else
+  let get_uint32 t i =
     let r = ba_get_int32 t.buffer (t.off+i) in
-    if swap then swap32 r else r [@@inline]
+    if Swap.swap then swap32 r else r [@@inline]
 
-let get_uint64 swap p t i =
-  if i > t.len - 8 || i < 0 then err_invalid_bounds (p ^ ".get_uint64") t i 8
-  else
+  let get_uint64 t i =
     let r = ba_get_int64 t.buffer (t.off+i) in
-    if swap then swap64 r else r [@@inline]
+    if Swap.swap then swap64 r else r [@@inline]
+end [@@inline]
+
+module Safe(Unsafe : GetterSetterWithSwap) = struct
+  module Unsafe = Unsafe
+  module Swap = Unsafe.Swap
+
+  let set_uint16 t i c =
+    if i > t.len - 2 || i < 0 then err_invalid_bounds (Swap.name ^ ".set_uint16") t i 2
+    else Unsafe.set_uint16 t i c [@@inline]
+
+  let set_uint32 t i c =
+    if i > t.len - 4 || i < 0 then err_invalid_bounds (Swap.name ^ ".set_uint32") t i 4
+    else Unsafe.set_uint32 t i c [@@inline]
+
+  let set_uint64 t i c =
+    if i > t.len - 8 || i < 0 then err_invalid_bounds (Swap.name ^ ".set_uint64") t i 8
+    else Unsafe.set_uint64 t i c [@@inline]
+
+  let get_uint16 t i =
+    if i > t.len - 2 || i < 0 then err_invalid_bounds (Swap.name ^ ".get_uint16") t i 2
+    else Unsafe.get_uint16 t i [@@inline]
+
+  let get_uint32 t i =
+    if i > t.len - 4 || i < 0 then err_invalid_bounds (Swap.name ^ ".get_uint32") t i 4
+    else Unsafe.get_uint32 t i [@@inline]
+
+  let get_uint64 t i =
+    if i > t.len - 8 || i < 0 then err_invalid_bounds (Swap.name ^ ".get_uint64") t i 8
+    else Unsafe.get_uint64 t i [@@inline]
+end [@@inline]
 
 module BE = struct
-  let set_uint16 t i c = set_uint16 (not Sys.big_endian) "BE" t i c [@@inline]
-  let set_uint32 t i c = set_uint32 (not Sys.big_endian) "BE" t i c [@@inline]
-  let set_uint64 t i c = set_uint64 (not Sys.big_endian) "BE" t i c [@@inline]
-  let get_uint16 t i = get_uint16 (not Sys.big_endian) "BE" t i [@@inline]
-  let get_uint32 t i = get_uint32 (not Sys.big_endian) "BE" t i [@@inline]
-  let get_uint64 t i = get_uint64 (not Sys.big_endian) "BE" t i [@@inline]
+  include Safe(Unsafe(struct
+                 let swap = not Sys.big_endian
+                 let name = "BE"
+               end))
 end
 
 module LE = struct
-  let set_uint16 t i c = set_uint16 Sys.big_endian "LE" t i c [@@inline]
-  let set_uint32 t i c = set_uint32 Sys.big_endian "LE" t i c [@@inline]
-  let set_uint64 t i c = set_uint64 Sys.big_endian "LE" t i c [@@inline]
-  let get_uint16 t i = get_uint16 Sys.big_endian "LE" t i [@@inline]
-  let get_uint32 t i = get_uint32 Sys.big_endian "LE" t i [@@inline]
-  let get_uint64 t i = get_uint64 Sys.big_endian "LE" t i [@@inline]
+  include Safe(Unsafe(struct
+                 let swap = Sys.big_endian
+                 let name = "LE"
+               end))
 end
 
 module HE = struct
-  let set_uint16 t i c = set_uint16 false "HE" t i c [@@inline]
-  let set_uint32 t i c = set_uint32 false "HE" t i c [@@inline]
-  let set_uint64 t i c = set_uint64 false "HE" t i c [@@inline]
-  let get_uint16 t i = get_uint16 false "HE" t i [@@inline]
-  let get_uint32 t i = get_uint32 false "HE" t i [@@inline]
-  let get_uint64 t i = get_uint64 false "HE" t i [@@inline]
+  include Safe(Unsafe(struct
+                 let swap = false
+                 let name = "HE"
+               end))
 end
 
 let length { len ; _ } = len

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -258,25 +258,30 @@ val check_alignment : t -> int -> bool
     boundary.
     @raise Invalid_argument if [alignment] is not a positive integer. *)
 
-val get_char: t -> int -> char
-(** [get_char t off] returns the character contained in the cstruct
-    at offset [off].
-    @raise Invalid_argument if the offset exceeds cstruct length. *)
+module type GetterSetterByte = sig
+  val get_char: t -> int -> char
+  (** [get_char t off] returns the character contained in the cstruct
+      at offset [off].
+      @raise Invalid_argument if the offset exceeds cstruct length. *)
 
-val get_uint8: t -> int -> uint8
-(** [get_uint8 t off] returns the byte contained in the cstruct
-    at offset [off].
-    @raise Invalid_argument if the offset exceeds cstruct length. *)
+  val get_uint8: t -> int -> uint8
+  (** [get_uint8 t off] returns the byte contained in the cstruct
+      at offset [off].
+      @raise Invalid_argument if the offset exceeds cstruct length. *)
 
-val set_char: t -> int -> char -> unit
-(** [set_char t off c] sets the byte contained in the cstruct
-    at offset [off] to character [c].
-    @raise Invalid_argument if the offset exceeds cstruct length. *)
+  val set_char: t -> int -> char -> unit
+  (** [set_char t off c] sets the byte contained in the cstruct
+      at offset [off] to character [c].
+      @raise Invalid_argument if the offset exceeds cstruct length. *)
 
-val set_uint8: t -> int -> uint8 -> unit
-(** [set_uint8 t off c] sets the byte contained in the cstruct
-    at offset [off] to byte [c].
-    @raise Invalid_argument if the offset exceeds cstruct length. *)
+  val set_uint8: t -> int -> uint8 -> unit
+  (** [set_uint8 t off c] sets the byte contained in the cstruct
+      at offset [off] to byte [c].
+      @raise Invalid_argument if the offset exceeds cstruct length. *)
+end
+include GetterSetterByte
+
+module Unsafe : GetterSetterByte
 
 val sub: t -> int -> int -> t
 (** [sub cstr off len] is [{ t with off = t.off + off; len }]
@@ -372,7 +377,7 @@ val to_bytes: ?off:int -> ?len:int -> t -> bytes
     @raise Invalid_argument if [off] or [len] is negative, or
     [Cstruct.length str - off] < [len]. *)
 
-module type GetterSetter = sig
+module type GetterSetterMultiByte = sig
   val get_uint16: t -> int -> uint16
   (** [get_uint16 cstr off] is the 16 bit long unsigned
       integer stored in [cstr] at offset [off].
@@ -409,9 +414,9 @@ module BE : sig
   (** Get/set big-endian integers of various sizes. The second
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
-  include GetterSetter
+  include GetterSetterMultiByte
 
-  module Unsafe : GetterSetter
+  module Unsafe : GetterSetterMultiByte
 end
 
 module LE : sig
@@ -420,9 +425,9 @@ module LE : sig
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
 
-  include GetterSetter
+  include GetterSetterMultiByte
 
-  module Unsafe : GetterSetter
+  module Unsafe : GetterSetterMultiByte
 end
 
 module HE : sig
@@ -431,9 +436,9 @@ module HE : sig
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
 
-  include GetterSetter
+  include GetterSetterMultiByte
 
-  module Unsafe : GetterSetter
+  module Unsafe : GetterSetterMultiByte
 end
 
 (** {2 Debugging } *)

--- a/lib/cstruct.mli
+++ b/lib/cstruct.mli
@@ -372,41 +372,46 @@ val to_bytes: ?off:int -> ?len:int -> t -> bytes
     @raise Invalid_argument if [off] or [len] is negative, or
     [Cstruct.length str - off] < [len]. *)
 
+module type GetterSetter = sig
+  val get_uint16: t -> int -> uint16
+  (** [get_uint16 cstr off] is the 16 bit long unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val get_uint32: t -> int -> uint32
+  (** [get_uint32 cstr off] is the 32 bit long unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val get_uint64: t -> int -> uint64
+  (** [get_uint64 cstr off] is the 64 bit long unsigned
+      integer stored in [cstr] at offset [off].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint16: t -> int -> uint16 -> unit
+  (** [set_uint16 cstr off i] writes the 16 bit long
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint32: t -> int -> uint32 -> unit
+  (** [set_uint32 cstr off i] writes the 32 bit long
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
+
+  val set_uint64: t -> int -> uint64 -> unit
+  (** [set_uint64 cstr off i] writes the 64 bit long
+      unsigned integer [i] at offset [off] of [cstr].
+      @raise Invalid_argument if the buffer is too small. *)
+end
+
 module BE : sig
 
   (** Get/set big-endian integers of various sizes. The second
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
+  include GetterSetter
 
-  val get_uint16: t -> int -> uint16
-  (** [get_uint16 cstr off] is the 16 bit long big-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val get_uint32: t -> int -> uint32
-  (** [get_uint32 cstr off] is the 32 bit long big-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val get_uint64: t -> int -> uint64
-  (** [get_uint64 cstr off] is the 64 bit long big-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint16: t -> int -> uint16 -> unit
-  (** [set_uint16 cstr off i] writes the 16 bit long big-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint32: t -> int -> uint32 -> unit
-  (** [set_uint32 cstr off i] writes the 32 bit long big-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint64: t -> int -> uint64 -> unit
-  (** [set_uint64 cstr off i] writes the 64 bit long big-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
+  module Unsafe : GetterSetter
 end
 
 module LE : sig
@@ -415,35 +420,9 @@ module LE : sig
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
 
-  val get_uint16: t -> int -> uint16
-  (** [get_uint16 cstr off] is the 16 bit long little-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
+  include GetterSetter
 
-  val get_uint32: t -> int -> uint32
-  (** [get_uint32 cstr off] is the 32 bit long little-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val get_uint64: t -> int -> uint64
-  (** [get_uint64 cstr off] is the 64 bit long little-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint16: t -> int -> uint16 -> unit
-  (** [set_uint16 cstr off i] writes the 16 bit long little-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint32: t -> int -> uint32 -> unit
-  (** [set_uint32 cstr off i] writes the 32 bit long little-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint64: t -> int -> uint64 -> unit
-  (** [set_uint64 cstr off i] writes the 64 bit long little-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
+  module Unsafe : GetterSetter
 end
 
 module HE : sig
@@ -452,35 +431,9 @@ module HE : sig
       argument of those functions is the position relative to the
       current offset of the cstruct. *)
 
-  val get_uint16: t -> int -> uint16
-  (** [get_uint16 cstr off] is the 16 bit long host-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
+  include GetterSetter
 
-  val get_uint32: t -> int -> uint32
-  (** [get_uint32 cstr off] is the 32 bit long host-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val get_uint64: t -> int -> uint64
-  (** [get_uint64 cstr off] is the 64 bit long host-endian unsigned
-      integer stored in [cstr] at offset [off].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint16: t -> int -> uint16 -> unit
-  (** [set_uint16 cstr off i] writes the 16 bit long host-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint32: t -> int -> uint32 -> unit
-  (** [set_uint32 cstr off i] writes the 32 bit long host-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
-
-  val set_uint64: t -> int -> uint64 -> unit
-  (** [set_uint64 cstr off i] writes the 64 bit long host-endian
-      unsigned integer [i] at offset [off] of [cstr].
-      @raise Invalid_argument if the buffer is too small. *)
+  module Unsafe : GetterSetter
 end
 
 (** {2 Debugging } *)


### PR DESCRIPTION
Add Unsafe operations to Cstruct, and the ppx generator.

Unsafe accessors are useful when it can be guaranteed that we will not access any values out of bounds, in order to not spend time on bounds checks.
For example if we wrap a cstruct `x` in an `X.t`, which is always of the right size, we do not have to force clients of that module to bounds check every access.